### PR TITLE
Add missing os import for tool runner

### DIFF
--- a/gui_pyside6/backend/tool_runner.py
+++ b/gui_pyside6/backend/tool_runner.py
@@ -1,8 +1,12 @@
 import subprocess
 from pathlib import Path
 import sys
+import os
 
-def run_tool_script(script_path: Path, env_path: Path | None = None) -> tuple[int, str, str]:
+
+def run_tool_script(
+    script_path: Path, env_path: Path | None = None
+) -> tuple[int, str, str]:
     """Runs a Python script from the /tools folder."""
     if not script_path.exists():
         raise FileNotFoundError(f"Script not found: {script_path}")


### PR DESCRIPTION
## Summary
- fix NameError in tool_runner by importing `os`

## Testing
- `ruff check gui_pyside6/backend/tool_runner.py`
- `black --check gui_pyside6/backend/tool_runner.py`
- `python - <<'PY'
from gui_pyside6.backend.tool_runner import run_tool_script
from pathlib import Path

try:
    print(run_tool_script(Path('nonexistent.py'), Path('/tmp')))
except FileNotFoundError as e:
    print('FileNotFoundError raised as expected')
PY
`

------
https://chatgpt.com/codex/tasks/task_e_684a98e3adb48329909266917e18e1da