### PR TITLE
Fix runtime path resolution

### DIFF
--- a/gui_pyside6/backend/agent_loader.py
+++ b/gui_pyside6/backend/agent_loader.py
@@ -1,7 +1,11 @@
 import json
 from pathlib import Path
 
-AGENTS_DIR = Path("resources/agents")
+# Resolve the agents directory relative to this module so the GUI can be run
+# from any working directory.
+AGENTS_DIR = (
+    Path(__file__).resolve().parent.parent / "resources" / "agents"
+)
 
 def load_agents() -> list[dict]:
     agents = []

--- a/gui_pyside6/backend/settings_manager.py
+++ b/gui_pyside6/backend/settings_manager.py
@@ -1,7 +1,11 @@
 import json
 from pathlib import Path
 
-SETTINGS_PATH = Path("config/settings.json")
+# Build the settings path relative to this module so the GUI can be started
+# from any working directory.
+SETTINGS_PATH = (
+    Path(__file__).resolve().parent.parent / "config" / "settings.json"
+)
 
 DEFAULT_SETTINGS = {
     "temperature": 0.5,


### PR DESCRIPTION
## Summary
- resolve agent preset directory relative to the backend module
- store settings relative to `backend` module so the GUI can run from any directory

## Testing
- `python -m py_compile gui_pyside6/backend/agent_loader.py gui_pyside6/backend/settings_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_684a99a2ad188329bc36f17093d57e00