### PR TITLE
Add PySide6 launcher

### DIFF
--- a/gui_pyside6/CONTRIBUTING.md
+++ b/gui_pyside6/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Optional: use `run_uv.bat` or `run_uv.sh` to automatically configure a new envir
 
 ```bash
 uv pip install -e .
-python gui_pyside6/main.py
+./run_pyside6.sh  # Windows: run_pyside6.bat
 ```
 
 ---
@@ -47,6 +47,8 @@ python gui_pyside6/main.py
 codex-gui/
 ├── gui_pyside6/
 │   ├── main.py             # Entry point
+│   ├── run_pyside6.sh      # Unix launcher
+│   ├── run_pyside6.bat     # Windows launcher
 │   ├── ui/                 # UI classes (PySide6)
 │   ├── backend/            # Codex adapters, tool runners
 │   ├── utils/              # Shared helpers

--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -28,7 +28,7 @@ This project reimagines the Codex CLI as a desktop application, offering:
 git clone https://github.com/AcTePuKc/codex-gui
 cd codex-gui
 pip install -r requirements.txt
-python main.py
+./run_pyside6.sh  # Windows: run_pyside6.bat
 ````
 
 > Requires Python 3.9+ and PySide6
@@ -39,6 +39,8 @@ python main.py
 codex-gui/
 ├── gui_pyside6/
 │   ├── main.py
+│   ├── run_pyside6.sh
+│   ├── run_pyside6.bat
 │   ├── ui/                   # UI components
 │   ├── backend/              # Logic & CLI adapters
 │   ├── utils/                # Helper functions

--- a/gui_pyside6/__init__.py
+++ b/gui_pyside6/__init__.py
@@ -1,0 +1,3 @@
+"""Hybrid PySide6 GUI package."""
+
+__all__ = []

--- a/gui_pyside6/main.py
+++ b/gui_pyside6/main.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import sys
+from PySide6.QtWidgets import QApplication, QLabel, QWidget, QVBoxLayout
+
+from .backend.agent_loader import load_agents
+from .backend.settings_manager import load_settings
+
+
+def main() -> None:
+    """Entry point for the Hybrid PySide6 GUI."""
+    app = QApplication(sys.argv)
+
+    agents = load_agents()
+    settings = load_settings()
+
+    window = QWidget()
+    window.setWindowTitle("Codex-GUI")
+    layout = QVBoxLayout(window)
+    info = QLabel(
+        f"Loaded {len(agents)} agents. Selected: {settings.get('selected_agent')}"
+    )
+    layout.addWidget(info)
+    window.resize(400, 200)
+    window.show()
+
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/gui_pyside6/run_pyside6.bat
+++ b/gui_pyside6/run_pyside6.bat
@@ -1,0 +1,2 @@
+@echo off
+python -m gui_pyside6.main %*

--- a/gui_pyside6/run_pyside6.sh
+++ b/gui_pyside6/run_pyside6.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+python -m gui_pyside6.main "$@"


### PR DESCRIPTION
## Summary
- add `gui_pyside6` package init
- create minimal PySide6 `main.py`
- include helper launch scripts for Windows and Unix
- document usage of the new scripts in README and CONTRIBUTING

## Testing
- `python scripts/asciicheck.py gui_pyside6/README.md gui_pyside6/CONTRIBUTING.md`
- `python -m gui_pyside6.main` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684a9a2af14c8329b21e5bdbd24eae4b