### PR TITLE
Add main window implementation

### DIFF
--- a/gui_pyside6/main.py
+++ b/gui_pyside6/main.py
@@ -1,27 +1,22 @@
 from __future__ import annotations
 
 import sys
-from PySide6.QtWidgets import QApplication, QLabel, QWidget, QVBoxLayout
+from PySide6.QtWidgets import QApplication
 
-from .backend.agent_loader import load_agents
 from .backend.settings_manager import load_settings
+from .backend.agent_manager import AgentManager
+from .ui import MainWindow
 
 
 def main() -> None:
     """Entry point for the Hybrid PySide6 GUI."""
     app = QApplication(sys.argv)
 
-    agents = load_agents()
-    settings = load_settings()
+    _ = load_settings()  # Load user settings for future use
+    agent_manager = AgentManager()
 
-    window = QWidget()
-    window.setWindowTitle("Codex-GUI")
-    layout = QVBoxLayout(window)
-    info = QLabel(
-        f"Loaded {len(agents)} agents. Selected: {settings.get('selected_agent')}"
-    )
-    layout.addWidget(info)
-    window.resize(400, 200)
+    window = MainWindow(agent_manager)
+    window.resize(800, 600)
     window.show()
 
     sys.exit(app.exec())

--- a/gui_pyside6/ui/__init__.py
+++ b/gui_pyside6/ui/__init__.py
@@ -1,0 +1,5 @@
+"""UI components for Codex-GUI."""
+
+from .main_window import MainWindow
+
+__all__ = ["MainWindow"]

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+
+from PySide6.QtCore import QThread, Signal
+from PySide6.QtWidgets import (
+    QComboBox,
+    QHBoxLayout,
+    QMainWindow,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+    QLabel,
+    QPlainTextEdit,
+)
+
+from ..backend import codex_adapter
+from ..backend.agent_manager import AgentManager
+
+
+class CodexWorker(QThread):
+    """Worker thread to stream Codex output."""
+
+    line_received = Signal(str)
+    finished = Signal()
+
+    def __init__(self, prompt: str, agent: dict) -> None:
+        super().__init__()
+        self.prompt = prompt
+        self.agent = agent
+
+    def run(self) -> None:  # type: ignore[override]
+        try:
+            for line in codex_adapter.start_session(self.prompt, self.agent):
+                self.line_received.emit(line)
+        except Exception as exc:  # pylint: disable=broad-except
+            self.line_received.emit(f"Error: {exc}")
+        finally:
+            self.finished.emit()
+
+
+class MainWindow(QMainWindow):
+    """Primary application window."""
+
+    def __init__(self, agent_manager: AgentManager) -> None:
+        super().__init__()
+        self.agent_manager = agent_manager
+        self.worker: CodexWorker | None = None
+
+        self.setWindowTitle("Codex-GUI")
+
+        central = QWidget(self)
+        self.setCentralWidget(central)
+
+        layout = QVBoxLayout(central)
+
+        top_bar = QHBoxLayout()
+        layout.addLayout(top_bar)
+
+        top_bar.addWidget(QLabel("Agent:"))
+        self.agent_combo = QComboBox()
+        self.agent_combo.addItems([a.get("name", "") for a in agent_manager.agents])
+        top_bar.addWidget(self.agent_combo)
+
+        self.settings_btn = QPushButton("Settings")
+        top_bar.addWidget(self.settings_btn)
+
+        self.prompt_edit = QPlainTextEdit()
+        self.prompt_edit.setPlaceholderText("Enter your prompt here...")
+        layout.addWidget(self.prompt_edit)
+
+        button_bar = QHBoxLayout()
+        layout.addLayout(button_bar)
+
+        self.run_btn = QPushButton("Run")
+        self.run_btn.clicked.connect(self.start_codex)
+        button_bar.addWidget(self.run_btn)
+
+        self.stop_btn = QPushButton("Stop")
+        self.stop_btn.setEnabled(False)
+        self.stop_btn.clicked.connect(self.stop_codex)
+        button_bar.addWidget(self.stop_btn)
+
+        self.output_view = QTextEdit()
+        self.output_view.setReadOnly(True)
+        layout.addWidget(self.output_view)
+
+    def start_codex(self) -> None:
+        if self.worker and self.worker.isRunning():
+            return
+        prompt = self.prompt_edit.toPlainText().strip()
+        agent_name = self.agent_combo.currentText()
+        self.agent_manager.set_active_agent(agent_name)
+        agent = self.agent_manager.active_agent or {}
+
+        self.output_view.clear()
+        self.worker = CodexWorker(prompt, agent)
+        self.worker.line_received.connect(self.append_output)
+        self.worker.finished.connect(self.session_finished)
+        self.worker.start()
+        self.run_btn.setEnabled(False)
+        self.stop_btn.setEnabled(True)
+
+    def append_output(self, text: str) -> None:
+        self.output_view.append(text)
+
+    def session_finished(self) -> None:
+        self.run_btn.setEnabled(True)
+        self.stop_btn.setEnabled(False)
+
+    def stop_codex(self) -> None:
+        codex_adapter.stop_session()
+        if self.worker and self.worker.isRunning():
+            self.worker.wait(1000)
+        self.session_finished()


### PR DESCRIPTION
## Summary
- create `MainWindow` with prompt, agent dropdown and Codex output area
- wire Run and Stop buttons to `codex_adapter`
- export `MainWindow` from `ui` package
- start the new window from `main.py`

## Testing
- `python -m py_compile gui_pyside6/ui/main_window.py gui_pyside6/main.py`
- `ruff gui_pyside6/ui/main_window.py gui_pyside6/main.py`

------
https://chatgpt.com/codex/tasks/task_e_684a9f0263c483298b74804d822015c4