### PR TITLE
Add basic plugin loader

### DIFF
--- a/gui_pyside6/plugins/loader.py
+++ b/gui_pyside6/plugins/loader.py
@@ -1,0 +1,54 @@
+import importlib
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+# Path to the manifest relative to this file
+_MANIFEST_PATH = Path(__file__).resolve().parent / "manifest.json"
+
+
+def _import_module(entry: str) -> ModuleType | None:
+    """Import a plugin module given its entry path."""
+    module_path = Path(entry)
+    # Convert entry like "plugins/syntax_formatter.py" to
+    # "gui_pyside6.plugins.syntax_formatter"
+    parts = module_path.with_suffix("").parts
+    module_name = ".".join(("gui_pyside6", *parts))
+    try:
+        return importlib.import_module(module_name)
+    except Exception as exc:  # pylint: disable=broad-except
+        print(f"Failed to import plugin {module_name}: {exc}")
+        return None
+
+
+def load_plugins(main_window: Any) -> None:
+    """Load and register enabled plugins into the given main window."""
+    if not _MANIFEST_PATH.exists():
+        return
+
+    try:
+        with _MANIFEST_PATH.open("r", encoding="utf-8") as fh:
+            manifest = json.load(fh)
+    except Exception as exc:  # pylint: disable=broad-except
+        print(f"Failed to read plugin manifest: {exc}")
+        return
+
+    for plugin in manifest.get("plugins", []):
+        if not plugin.get("enabled", False):
+            continue
+
+        entry = plugin.get("entry")
+        if not entry:
+            continue
+
+        module = _import_module(entry)
+        if not module:
+            continue
+
+        register = getattr(module, "register", None)
+        if callable(register):
+            try:
+                register(main_window)
+            except Exception as exc:  # pylint: disable=broad-except
+                print(f"Plugin {entry} failed during register(): {exc}")

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (
 
 from ..backend import codex_adapter
 from ..backend.agent_manager import AgentManager
+from ..plugins.loader import load_plugins
 
 
 class CodexWorker(QThread):
@@ -84,6 +85,9 @@ class MainWindow(QMainWindow):
         self.output_view = QTextEdit()
         self.output_view.setReadOnly(True)
         layout.addWidget(self.output_view)
+
+        # Load optional plugins defined in plugins/manifest.json
+        load_plugins(self)
 
     def start_codex(self) -> None:
         if self.worker and self.worker.isRunning():


### PR DESCRIPTION
## Summary
- implement plugin loader for the PySide6 app
- invoke plugin loader from `MainWindow` once the UI is set up

## Testing
- `ruff check .`
- `black --check plugins/loader.py ui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_684aa008d9b0832999488948dab59f34