### PR TITLE
Add backend installer and optional requirements

### DIFF
--- a/gui_pyside6/backend/backend_installer.py
+++ b/gui_pyside6/backend/backend_installer.py
@@ -1,0 +1,54 @@
+"""Utility for installing optional backend dependencies."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import venv
+from pathlib import Path
+
+
+_REQUIREMENTS_PATH = Path(__file__).resolve().parent / "backend_requirements.json"
+
+
+def _load_requirements() -> dict[str, list[str]]:
+    if not _REQUIREMENTS_PATH.exists():
+        return {}
+    try:
+        with _REQUIREMENTS_PATH.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception as exc:  # pylint: disable=broad-except
+        print(f"Failed to read {_REQUIREMENTS_PATH}: {exc}")
+        return {}
+
+
+def _ensure_venv(path: Path) -> Path:
+    """Create a virtual environment at the given path if it doesn't exist."""
+    python_path = path / ("Scripts" if os.name == "nt" else "bin") / "python"
+    if not python_path.exists():
+        builder = venv.EnvBuilder(with_pip=True)
+        builder.create(path)
+    return python_path
+
+
+def ensure_backend_installed(backend_name: str) -> None:
+    """Install optional packages for the given backend if needed."""
+    requirements = _load_requirements()
+    packages = requirements.get(backend_name)
+    if not packages:
+        return
+
+    if sys.prefix != sys.base_prefix:
+        python = Path(sys.executable)
+    else:
+        venv_dir = Path.home() / ".hybrid_tts" / "venv"
+        python = _ensure_venv(venv_dir)
+
+    cmd = [str(python), "-m", "pip", "install", *packages]
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as exc:
+        print(f"Failed to install packages for {backend_name}: {exc}")
+

--- a/gui_pyside6/backend/backend_requirements.json
+++ b/gui_pyside6/backend/backend_requirements.json
@@ -1,0 +1,10 @@
+{
+    "chatterbox": ["chatterbox>=0.0"],
+    "coqui": ["TTS>=0.15.0"],
+    "edge": ["edge-tts>=6.1"],
+    "elevenlabs": ["elevenlabs>=0.2"],
+    "gtts": ["gTTS>=2.3"],
+    "kokoro": ["kokoro>=0.9"],
+    "openaudio-s1-mini": ["openaudio-s1-mini>=0.1"],
+    "piper": ["piper-tts>=0.0.2"]
+}

--- a/gui_pyside6/backend/tool_runner.py
+++ b/gui_pyside6/backend/tool_runner.py
@@ -3,13 +3,20 @@ from pathlib import Path
 import sys
 import os
 
+from .backend_installer import ensure_backend_installed
+
 
 def run_tool_script(
-    script_path: Path, env_path: Path | None = None
+    script_path: Path,
+    env_path: Path | None = None,
+    backend_name: str | None = None,
 ) -> tuple[int, str, str]:
-    """Runs a Python script from the /tools folder."""
+    """Run a Python script from the /tools folder, installing backend deps."""
     if not script_path.exists():
         raise FileNotFoundError(f"Script not found: {script_path}")
+
+    if backend_name:
+        ensure_backend_installed(backend_name)
 
     cmd = [sys.executable, str(script_path)]
 


### PR DESCRIPTION
## Summary
- include optional backend packages in `backend_requirements.json`
- add `ensure_backend_installed()` helper to manage backend dependencies
- make `run_tool_script()` install backend deps before execution
- add chatterbox, kokoro and openaudio-s1-mini to optional packages

## Testing
- `python -m py_compile gui_pyside6/backend/backend_installer.py gui_pyside6/backend/tool_runner.py`
- `./scripts/asciicheck.py gui_pyside6/backend/backend_installer.py gui_pyside6/backend/backend_requirements.json gui_pyside6/backend/tool_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_684aa0d181048329807e349ffbd567b1