### PR TITLE
Persist agent and runtime settings

### DIFF
--- a/gui_pyside6/main.py
+++ b/gui_pyside6/main.py
@@ -12,10 +12,11 @@ def main() -> None:
     """Entry point for the Hybrid PySide6 GUI."""
     app = QApplication(sys.argv)
 
-    _ = load_settings()  # Load user settings for future use
+    settings = load_settings()
     agent_manager = AgentManager()
+    agent_manager.set_active_agent(settings.get("selected_agent", ""))
 
-    window = MainWindow(agent_manager)
+    window = MainWindow(agent_manager, settings)
     window.resize(800, 600)
     window.show()
 

--- a/gui_pyside6/ui/__init__.py
+++ b/gui_pyside6/ui/__init__.py
@@ -1,5 +1,6 @@
 """UI components for Codex-GUI."""
 
 from .main_window import MainWindow
+from .settings_dialog import SettingsDialog
 
-__all__ = ["MainWindow"]
+__all__ = ["MainWindow", "SettingsDialog"]

--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QVBoxLayout,
+    QLabel,
+    QDoubleSpinBox,
+    QSpinBox,
+    QWidget,
+)
+
+from ..backend.settings_manager import save_settings
+
+
+class SettingsDialog(QDialog):
+    """Dialog for modifying runtime settings."""
+
+    def __init__(self, settings: dict, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.settings = settings
+        self.setWindowTitle("Settings")
+
+        layout = QVBoxLayout(self)
+
+        layout.addWidget(QLabel("Temperature:"))
+        self.temp_spin = QDoubleSpinBox()
+        self.temp_spin.setRange(0.0, 1.0)
+        self.temp_spin.setSingleStep(0.1)
+        self.temp_spin.setValue(float(settings.get("temperature", 0.5)))
+        layout.addWidget(self.temp_spin)
+
+        layout.addWidget(QLabel("Max Tokens:"))
+        self.max_spin = QSpinBox()
+        self.max_spin.setRange(1, 4096)
+        self.max_spin.setValue(int(settings.get("max_tokens", 1024)))
+        layout.addWidget(self.max_spin)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def accept(self) -> None:  # type: ignore[override]
+        self.settings["temperature"] = float(self.temp_spin.value())
+        self.settings["max_tokens"] = int(self.max_spin.value())
+        save_settings(self.settings)
+        super().accept()


### PR DESCRIPTION
## Summary
- save selected agent and runtime options to `config/settings.json`
- load saved settings on startup
- add a simple settings dialog
- save the active agent when changed

## Testing
- `python3 -m py_compile gui_pyside6/ui/main_window.py gui_pyside6/ui/settings_dialog.py gui_pyside6/main.py gui_pyside6/backend/settings_manager.py gui_pyside6/backend/agent_manager.py`
- `black gui_pyside6/ui/main_window.py gui_pyside6/ui/settings_dialog.py gui_pyside6/main.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684aa2ee9524832997f00938f196424c