### PR TITLE
Update hybrid docs for uv setup

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -26,8 +26,9 @@ This project reimagines the Codex CLI as a desktop application, offering:
 
 ```bash
 git clone https://github.com/AcTePuKc/codex-gui
-cd codex-gui
-pip install -r requirements.txt
+cd codex-gui/gui_pyside6
+pip install uv
+uv pip install -r requirements.uv.in
 ./run_pyside6.sh  # Windows: run_pyside6.bat
 ````
 
@@ -58,6 +59,12 @@ For agent presets, architecture decisions, and developer info, see:
 * [AGENTS.md](./AGENTS.md)
 * [CONTRIBUTING.md](./CONTRIBUTING.md)
 * [docs/index.md](./docs/index.md)
+
+## 🔌 Plugins & Backends
+
+Plugins listed in `plugins/manifest.json` are loaded at startup using `load_plugins`. Create a Python module under `plugins/` and enable it in the manifest to extend the UI.
+
+Some plugins rely on optional TTS backends. These dependencies are installed on demand via `ensure_backend_installed()` which detects your active virtual environment or falls back to `~/.hybrid_tts/venv`.
 
 ## 🙏 Credits
 

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -12,11 +12,13 @@ This app transforms the CLI-based Codex experience into a rich, extensible deskt
 ## 🔗 Contents
 
 - [Overview](#overview)
+- [Launching](#launching)
 - [Architecture](#architecture)
 - [UI Components](#ui-components)
 - [Agent System](#agent-system)
 - [Tool Execution](#tool-execution)
 - [Plugin/Extension Support](#planned-pluginextension-support)
+- [Custom Agents/Plugins](#custom-agentsplugins)
 - [Roadmap](#roadmap)
 - [FAQ](#faq)
 
@@ -30,6 +32,18 @@ Codex-GUI is designed for developers who want a more interactive experience with
 - Generate and test code live inside a `tools/` sandbox
 - Visualize file context, syntax, and output
 - Manage prompt history and multi-tab sessions
+
+---
+
+## 🚀 Launching {#launching}
+
+1. Install [`uv`](https://github.com/astral-sh/uv).
+2. From the `gui_pyside6` folder run:
+
+```bash
+uv pip install -r requirements.uv.in
+./run_pyside6.sh  # Windows: run_pyside6.bat
+```
 
 ---
 
@@ -109,6 +123,14 @@ Planned plugin architecture will allow:
 - Custom GUI panels via Python modules
 
 Plugins will live in `plugins/` and use a manifest system.
+
+---
+
+## 🛠️ Custom Agents/Plugins {#custom-agentsplugins}
+
+- **Agents**: Drop a JSON file into `resources/agents/`. New files are loaded on startup.
+- **Plugins**: Add a Python module under `plugins/` and list it in `plugins/manifest.json`. Only entries with `"enabled": true` are imported.
+- Some plugins require additional packages. The helper `ensure_backend_installed()` installs these into the active environment or `~/.hybrid_tts/venv` when needed.
 
 ---
 


### PR DESCRIPTION
## Summary
- update installation steps in PySide6 README
- document plugin loading and optional backend installation
- add launch instructions to docs landing page
- document custom agent and plugin steps

## Testing
- `ruff check gui_pyside6`

------
https://chatgpt.com/codex/tasks/task_e_684aa417d4e4832998c205c0079a81f8