### PR TITLE
Add example plugins for PySide6 GUI

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -64,6 +64,11 @@ For agent presets, architecture decisions, and developer info, see:
 
 Plugins listed in `plugins/manifest.json` are loaded at startup using `load_plugins`. Create a Python module under `plugins/` and enable it in the manifest to extend the UI.
 
+Example plugins included:
+
+- **Syntax Formatter** – adds a *Format* button that runs the Black formatter on the prompt editor.
+- **Agent Logger** – records prompts and responses to `agent_log.txt` when enabled.
+
 Some plugins rely on optional TTS backends. These dependencies are installed on demand via `ensure_backend_installed()` which detects your active virtual environment or falls back to `~/.hybrid_tts/venv`.
 
 ## 🙏 Credits

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -124,6 +124,11 @@ Planned plugin architecture will allow:
 
 Plugins will live in `plugins/` and use a manifest system.
 
+Current examples:
+
+- **Syntax Formatter** – adds a button that formats the prompt using Black.
+- **Agent Logger** – saves prompts and responses to `agent_log.txt` when enabled.
+
 ---
 
 ## 🛠️ Custom Agents/Plugins {#custom-agentsplugins}

--- a/gui_pyside6/plugins/agent_logger.py
+++ b/gui_pyside6/plugins/agent_logger.py
@@ -1,0 +1,29 @@
+"""Plugin that logs prompts and responses to a file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from datetime import datetime
+
+
+def register(window) -> None:
+    """Register the plugin with the main window."""
+    log_file = Path("agent_log.txt")
+
+    def log_prompt() -> None:
+        prompt = window.prompt_edit.toPlainText()
+        agent = window.agent_combo.currentText()
+        with log_file.open("a", encoding="utf-8") as fh:
+            fh.write(f"\n[{datetime.now().isoformat()}] Agent: {agent}\n")
+            fh.write(prompt + "\n")
+
+    def wrap_append(original_func):
+        def inner(text: str) -> None:
+            with log_file.open("a", encoding="utf-8") as fh:
+                fh.write(text + "\n")
+            original_func(text)
+
+        return inner
+
+    window.run_btn.clicked.connect(log_prompt)
+    window.append_output = wrap_append(window.append_output)

--- a/gui_pyside6/plugins/syntax_formatter.py
+++ b/gui_pyside6/plugins/syntax_formatter.py
@@ -1,0 +1,52 @@
+"""Plugin that adds a Format button to the main window."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from PySide6.QtWidgets import QPushButton
+
+
+def _ensure_black() -> None:
+    """Ensure the ``black`` package is available."""
+    try:
+        import black  # type: ignore  # noqa: F401
+    except Exception:  # pylint: disable=broad-except
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "black"])
+
+
+def _format_text(text: str) -> str:
+    """Format the given Python code using ``black``."""
+    with tempfile.NamedTemporaryFile("w+", delete=False, suffix=".py") as tmp:
+        tmp.write(text)
+        tmp.flush()
+        tmp_path = Path(tmp.name)
+
+    subprocess.run([sys.executable, "-m", "black", "-q", str(tmp_path)], check=False)
+    formatted = tmp_path.read_text(encoding="utf-8")
+    tmp_path.unlink(missing_ok=True)
+    return formatted
+
+
+def register(window) -> None:
+    """Register the plugin with the main window."""
+    _ensure_black()
+
+    button = QPushButton("Format")
+    window.button_bar.addWidget(button)
+
+    def on_click() -> None:
+        original = window.prompt_edit.toPlainText()
+        if not original.strip():
+            return
+        try:
+            formatted = _format_text(original)
+        except Exception as exc:  # pylint: disable=broad-except
+            window.output_view.append(f"Format error: {exc}")
+            return
+        window.prompt_edit.setPlainText(formatted)
+
+    button.clicked.connect(on_click)

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -81,6 +81,7 @@ class MainWindow(QMainWindow):
 
         button_bar = QHBoxLayout()
         layout.addLayout(button_bar)
+        self.button_bar = button_bar
 
         self.run_btn = QPushButton("Run")
         self.run_btn.clicked.connect(self.start_codex)


### PR DESCRIPTION
## Summary
- create `syntax_formatter` plugin that adds a Format button
- create `agent_logger` plugin that logs prompts and responses
- expose `button_bar` in `MainWindow` for plugin use
- document the new plugins in README and docs

## Testing
- `ruff check plugins/syntax_formatter.py plugins/agent_logger.py ui/main_window.py`
- `black plugins/syntax_formatter.py plugins/agent_logger.py ui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_684aa6897fa48329936de5c276440c5e