### PR TITLE
Update docs on backend installer

### DIFF
--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -136,7 +136,7 @@ Current examples:
 - **Agents**: Drop a JSON file into `resources/agents/`. New files are loaded on startup.
 - **Plugins**: Place your module inside `gui_pyside6/plugins/` and list it in `plugins/manifest.json`. Only entries with `"enabled": true` are imported.
 - **Interface**: Each plugin exports a `register(window)` function which receives the main window instance so you can add widgets or hook signals.
-- Some plugins require additional packages. The helper `ensure_backend_installed()` installs these into the active environment or `~/.hybrid_tts/venv` when needed.
+- Some plugins require additional packages. The helper `ensure_backend_installed()` first checks if you are running inside a virtual environment. If not, it creates a user-scoped environment at `~/.hybrid_tts/venv` (Windows: `%USERPROFILE%\.hybrid_tts\venv`) and installs the dependencies there. Activate your own virtual environment before launching the app if you want packages to be installed elsewhere.
 
 ---
 


### PR DESCRIPTION
## Summary
- mention per-user `~/.hybrid_tts/venv` in docs
- explain how developers can use their own virtual env

## Testing
- `pnpm format`
- `pnpm lint` *(fails: ESLint couldn't find configuration)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab24ca0e08329ac446c979a07226e