### PR TITLE
Add TTS Player plugin

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -73,6 +73,7 @@ Example plugins included:
 
 - **Syntax Formatter** – adds a *Format* button that runs the Black formatter on the prompt editor.
 - **Agent Logger** – records prompts and responses to `agent_log.txt` when enabled.
+- **TTS Player** – speaks the current prompt using gTTS (disabled by default).
 
 Some plugins rely on optional TTS backends. These dependencies are installed on demand via `ensure_backend_installed()` which detects your active virtual environment or falls back to `~/.hybrid_tts/venv`.
 

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -128,6 +128,7 @@ Current examples:
 
 - **Syntax Formatter** – adds a button that formats the prompt using Black.
 - **Agent Logger** – saves prompts and responses to `agent_log.txt` when enabled.
+- **TTS Player** – speaks the current prompt using gTTS (disabled by default).
 
 ---
 

--- a/gui_pyside6/plugins/manifest.json
+++ b/gui_pyside6/plugins/manifest.json
@@ -9,6 +9,11 @@
       "name": "Agent Logger",
       "entry": "plugins/agent_logger.py",
       "enabled": false
+    },
+    {
+      "name": "TTS Player",
+      "entry": "plugins/tts_player.py",
+      "enabled": false
     }
   ]
 }

--- a/gui_pyside6/plugins/tts_player.py
+++ b/gui_pyside6/plugins/tts_player.py
@@ -1,0 +1,49 @@
+"""Plugin that speaks text using gTTS."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from PySide6.QtCore import QUrl
+from PySide6.QtMultimedia import QAudioOutput, QMediaPlayer
+from PySide6.QtWidgets import QPushButton
+
+from ..backend.backend_installer import ensure_backend_installed
+
+
+def register(window) -> None:
+    """Register the plugin with the main window."""
+    button = QPushButton("Speak")
+    window.button_bar.addWidget(button)
+
+    player = QMediaPlayer()
+    audio_output = QAudioOutput()
+    player.setAudioOutput(audio_output)
+
+    def cleanup(tmp_path: Path) -> None:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+
+    def on_finished() -> None:
+        cleanup(current[0])
+
+    current: list[Path] = [Path()]
+    player.playbackStateChanged.connect(lambda _: on_finished())
+
+    def on_click() -> None:
+        text = window.prompt_edit.toPlainText().strip()
+        if not text:
+            return
+
+        ensure_backend_installed("gtts")
+        from gtts import gTTS
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".mp3") as tmp:
+            gTTS(text).save(tmp.name)
+            tmp_path = Path(tmp.name)
+        current[0] = tmp_path
+        player.setSource(QUrl.fromLocalFile(str(tmp_path)))
+        player.play()
+
+    button.clicked.connect(on_click)


### PR DESCRIPTION
## Summary
- add `tts_player.py` plugin that uses gTTS for speech
- register the new plugin in `plugins/manifest.json` (disabled by default)
- document the plugin in README and docs

## Testing
- `ruff check gui_pyside6/plugins/tts_player.py`

------
https://chatgpt.com/codex/tasks/task_e_684ab352a30c83299184fafc350fdc61