### PR TITLE
Add agent selection list widget

### DIFF
--- a/gui_pyside6/plugins/agent_logger.py
+++ b/gui_pyside6/plugins/agent_logger.py
@@ -12,7 +12,8 @@ def register(window) -> None:
 
     def log_prompt() -> None:
         prompt = window.prompt_edit.toPlainText()
-        agent = window.agent_combo.currentText()
+        current = window.agent_list.currentItem()
+        agent = current.text() if current else ""
         with log_file.open("a", encoding="utf-8") as fh:
             fh.write(f"\n[{datetime.now().isoformat()}] Agent: {agent}\n")
             fh.write(prompt + "\n")

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -106,7 +106,12 @@ class MainWindow(QMainWindow):
         current_name = self.settings.get("selected_agent", "")
         matches = self.agent_list.findItems(current_name, Qt.MatchExactly)
         if matches:
-            self.agent_list.setCurrentItem(matches[0])
+            item = matches[0]
+            self.agent_list.setCurrentItem(item)
+            self.agent_manager.set_active_agent(item.text())
+        elif self.agent_list.count() > 0:
+            self.agent_list.setCurrentRow(0)
+            self.agent_manager.set_active_agent(self.agent_list.currentItem().text())
         self.agent_list.currentTextChanged.connect(self.on_agent_changed)
         left_layout.addWidget(self.agent_list)
 


### PR DESCRIPTION
## Summary
- replace legacy combobox usage with agent_list in agent_logger plugin
- ensure agent list widget sets active agent on startup

## Testing
- `ruff check .`
- `black plugins/agent_logger.py ui/main_window.py --check`

------
https://chatgpt.com/codex/tasks/task_e_684ab99031948329a93cb9d5ef4f6def