### PR TITLE
Check Codex CLI availability

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -190,6 +190,12 @@ class MainWindow(QMainWindow):
     def start_codex(self) -> None:
         if self.worker and self.worker.isRunning():
             return
+        try:
+            codex_adapter.ensure_cli_available()
+        except FileNotFoundError as exc:
+            QMessageBox.warning(self, "Codex CLI Missing", str(exc))
+            self.status_bar.showMessage(str(exc))
+            return
         prompt = self.prompt_edit.toPlainText().strip()
         agent_item = self.agent_list.currentItem()
         agent_name = agent_item.text() if agent_item else ""


### PR DESCRIPTION
## Summary
- add helper `ensure_cli_available()` that verifies the Codex CLI
- warn user from the GUI if the CLI is missing

## Testing
- `ruff check gui_pyside6/backend/codex_adapter.py gui_pyside6/ui/main_window.py`
- `pnpm run format`

------
https://chatgpt.com/codex/tasks/task_e_684abd04436083298ce92ba92868a439