### PR TITLE
Add settings to Codex session

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -21,6 +21,7 @@ This project reimagines the Codex CLI as a desktop application, offering:
 - Agent presets with editable configs
 - Live preview of completions
 - Export/import conversations
+- Runtime settings like temperature and max tokens passed as CLI flags
 
 ## 📝 Prerequisites
 


### PR DESCRIPTION
## Summary
- allow `codex_adapter.start_session` to receive optional settings
- forward settings to CLI flags when not provided by agent
- update `CodexWorker` and `MainWindow` to pass settings
- document new behavior in README

## Testing
- `ruff check gui_pyside6/backend/codex_adapter.py gui_pyside6/ui/main_window.py`
- `black --check gui_pyside6/backend/codex_adapter.py gui_pyside6/ui/main_window.py`
- `python -m compileall gui_pyside6`

------
https://chatgpt.com/codex/tasks/task_e_684ac3c133f8832987b6ebef59f92d4e