### PR TITLE
Add configurable CLI path

### DIFF
--- a/gui_pyside6/backend/settings_manager.py
+++ b/gui_pyside6/backend/settings_manager.py
@@ -10,14 +10,22 @@ SETTINGS_PATH = (
 DEFAULT_SETTINGS = {
     "temperature": 0.5,
     "max_tokens": 1024,
-    "selected_agent": "Python Expert"
+    "selected_agent": "Python Expert",
+    # Optional path to the Codex CLI executable. If empty, the adapter will
+    # search the system PATH or use the bundled Node.js script.
+    "cli_path": ""
 }
 
 def load_settings() -> dict:
-    if not SETTINGS_PATH.exists():
-        return DEFAULT_SETTINGS.copy()
-    with SETTINGS_PATH.open("r", encoding="utf-8") as f:
-        return json.load(f)
+    settings = DEFAULT_SETTINGS.copy()
+    if SETTINGS_PATH.exists():
+        with SETTINGS_PATH.open("r", encoding="utf-8") as f:
+            try:
+                loaded = json.load(f)
+            except json.JSONDecodeError:
+                loaded = {}
+        settings.update(loaded)
+    return settings
 
 def save_settings(settings: dict) -> None:
     SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -193,7 +193,7 @@ class MainWindow(QMainWindow):
         if self.worker and self.worker.isRunning():
             return
         try:
-            codex_adapter.ensure_cli_available()
+            codex_adapter.ensure_cli_available(self.settings)
         except FileNotFoundError as exc:
             QMessageBox.warning(self, "Codex CLI Missing", str(exc))
             self.status_bar.showMessage(str(exc))

--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -4,9 +4,13 @@ from PySide6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QVBoxLayout,
+    QHBoxLayout,
     QLabel,
     QDoubleSpinBox,
     QSpinBox,
+    QLineEdit,
+    QPushButton,
+    QFileDialog,
     QWidget,
 )
 
@@ -36,6 +40,18 @@ class SettingsDialog(QDialog):
         self.max_spin.setValue(int(settings.get("max_tokens", 1024)))
         layout.addWidget(self.max_spin)
 
+        layout.addWidget(QLabel("Codex CLI Path:"))
+        cli_row = QWidget()
+        cli_layout = QHBoxLayout(cli_row)
+        cli_layout.setContentsMargins(0, 0, 0, 0)
+        self.cli_edit = QLineEdit()
+        self.cli_edit.setText(settings.get("cli_path", ""))
+        browse_btn = QPushButton("Browse")
+        browse_btn.clicked.connect(self.browse_cli)
+        cli_layout.addWidget(self.cli_edit)
+        cli_layout.addWidget(browse_btn)
+        layout.addWidget(cli_row)
+
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
@@ -44,5 +60,17 @@ class SettingsDialog(QDialog):
     def accept(self) -> None:  # type: ignore[override]
         self.settings["temperature"] = float(self.temp_spin.value())
         self.settings["max_tokens"] = int(self.max_spin.value())
+        self.settings["cli_path"] = self.cli_edit.text().strip()
         save_settings(self.settings)
         super().accept()
+
+    def browse_cli(self) -> None:
+        """Prompt the user to select the Codex CLI executable."""
+        filename, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select Codex CLI",
+            str(self.cli_edit.text() or ""),
+        )
+        if filename:
+            self.cli_edit.setText(filename)
+


### PR DESCRIPTION
## Summary
- extend settings to persist `cli_path`
- allow browsing for executable in Settings dialog
- check custom path before defaults when launching CLI

## Testing
- `python3 scripts/asciicheck.py README.md`
- `python3 scripts/readme_toc.py README.md`
- `python3 -m py_compile gui_pyside6/backend/codex_adapter.py gui_pyside6/backend/settings_manager.py gui_pyside6/ui/main_window.py gui_pyside6/ui/settings_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_684ac54bc7cc8329b22f0dab8242b531