### PR TITLE
Handle stderr from Codex CLI

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -77,6 +77,7 @@ The window is split into three panels using a horizontal splitter:
 
 A toolbar at the top mirrors the **Run** and **Stop** actions found below the
 editor. The status bar reports which agent is active and session progress.
+If the Codex CLI encounters an error, its stderr output will appear in the output panel.
 
 ## 📚 Docs
 

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -100,6 +100,7 @@ The main window uses a horizontal splitter:
 
 Run and Stop actions appear in both a toolbar at the top and a button bar below
 the editor. The bottom status bar shows the active agent and session updates.
+If the CLI fails, its stderr messages are printed in the output panel.
 
 ---
 


### PR DESCRIPTION
## Summary
- raise `CodexError` when the CLI fails and expose its stderr
- show stderr lines in the UI via `CodexWorker`
- display error lines in red in the output view
- note CLI error output in docs

## Testing
- `python -m compileall gui_pyside6`

------
https://chatgpt.com/codex/tasks/task_e_684ac6ae0cc883299035f942bfb0998e