### PR TITLE
Add verbose mode setting

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -23,6 +23,7 @@ This project reimagines the Codex CLI as a desktop application, offering:
 - Export/import conversations
 - Runtime settings like temperature and max tokens passed as CLI flags
 - Remembers the last selected agent across restarts
+- Optional verbose mode prints the exact CLI command before execution
 
 ## 📝 Prerequisites
 

--- a/gui_pyside6/backend/settings_manager.py
+++ b/gui_pyside6/backend/settings_manager.py
@@ -3,9 +3,7 @@ from pathlib import Path
 
 # Build the settings path relative to this module so the GUI can be started
 # from any working directory.
-SETTINGS_PATH = (
-    Path(__file__).resolve().parent.parent / "config" / "settings.json"
-)
+SETTINGS_PATH = Path(__file__).resolve().parent.parent / "config" / "settings.json"
 
 DEFAULT_SETTINGS = {
     "temperature": 0.5,
@@ -13,8 +11,11 @@ DEFAULT_SETTINGS = {
     "selected_agent": "Python Expert",
     # Optional path to the Codex CLI executable. If empty, the adapter will
     # search the system PATH or use the bundled Node.js script.
-    "cli_path": ""
+    "cli_path": "",
+    # Print the final CLI command in the output view when running a session.
+    "verbose": False,
 }
+
 
 def load_settings() -> dict:
     settings = DEFAULT_SETTINGS.copy()
@@ -26,6 +27,7 @@ def load_settings() -> dict:
                 loaded = {}
         settings.update(loaded)
     return settings
+
 
 def save_settings(settings: dict) -> None:
     SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -88,6 +88,8 @@ Key modules:
 
 All components are modular for future plugins.
 
+Enable **Verbose Mode** in the settings dialog to print the final CLI command before each run.
+
 ---
 
 ## 🗺️ IDE Layout

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -217,6 +217,9 @@ class MainWindow(QMainWindow):
         agent = self.agent_manager.active_agent or {}
 
         self.output_view.clear()
+        cmd = codex_adapter.build_command(prompt, agent, self.settings)
+        if self.settings.get("verbose"):
+            self.append_output("$ " + " ".join(cmd))
         self.worker = CodexWorker(prompt, agent, self.settings)
         self.worker.line_received.connect(self.append_output)
         self.worker.finished.connect(self.session_finished)

--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -11,6 +11,7 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QPushButton,
     QFileDialog,
+    QCheckBox,
     QWidget,
 )
 
@@ -52,6 +53,10 @@ class SettingsDialog(QDialog):
         cli_layout.addWidget(browse_btn)
         layout.addWidget(cli_row)
 
+        self.verbose_check = QCheckBox("Verbose")
+        self.verbose_check.setChecked(bool(settings.get("verbose", False)))
+        layout.addWidget(self.verbose_check)
+
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
@@ -61,6 +66,7 @@ class SettingsDialog(QDialog):
         self.settings["temperature"] = float(self.temp_spin.value())
         self.settings["max_tokens"] = int(self.max_spin.value())
         self.settings["cli_path"] = self.cli_edit.text().strip()
+        self.settings["verbose"] = self.verbose_check.isChecked()
         save_settings(self.settings)
         super().accept()
 
@@ -73,4 +79,3 @@ class SettingsDialog(QDialog):
         )
         if filename:
             self.cli_edit.setText(filename)
-


### PR DESCRIPTION
## Summary
- add `verbose` flag to settings
- show executed CLI command when verbose is enabled
- expose verbose option in settings dialog
- document feature in README and docs

## Testing
- `ruff check gui_pyside6`
- `black gui_pyside6/backend/codex_adapter.py gui_pyside6/backend/settings_manager.py gui_pyside6/ui/main_window.py gui_pyside6/ui/settings_dialog.py`
- `python -m py_compile gui_pyside6/backend/codex_adapter.py gui_pyside6/backend/settings_manager.py gui_pyside6/ui/main_window.py gui_pyside6/ui/settings_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_684ac88d8a6483299d9acf9491d61186