### PR TITLE
Extend settings dialog

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -21,9 +21,11 @@ This project reimagines the Codex CLI as a desktop application, offering:
 - Agent presets with editable configs
 - Live preview of completions
 - Export/import conversations
-- Runtime settings like temperature and max tokens passed as CLI flags
+- Runtime settings for temperature, model, provider, penalties and more passed as CLI flags
 - Remembers the last selected agent across restarts
 - Optional verbose mode prints the exact CLI command before execution
+- Additional options for provider, model, top-p, frequency and presence penalties,
+  approval mode with auto-edit/full-auto toggles, reasoning effort and flex mode
 
 ## 📝 Prerequisites
 

--- a/gui_pyside6/backend/codex_adapter.py
+++ b/gui_pyside6/backend/codex_adapter.py
@@ -110,6 +110,15 @@ def build_command(prompt: str, agent: dict, settings: dict | None = None) -> lis
         "frequency_penalty": "--frequency-penalty",
         "presence_penalty": "--presence-penalty",
         "model": "--model",
+        "provider": "--provider",
+        "approval_mode": "--approval-mode",
+        "reasoning": "--reasoning",
+    }
+
+    bool_flags = {
+        "auto_edit": "--auto-edit",
+        "full_auto": "--full-auto",
+        "flex_mode": "--flex-mode",
     }
 
     for key, flag in flag_map.items():
@@ -117,6 +126,11 @@ def build_command(prompt: str, agent: dict, settings: dict | None = None) -> lis
             add_flag(flag, agent[key])
         elif key in settings:
             add_flag(flag, settings[key])
+
+    for key, flag in bool_flags.items():
+        value = agent.get(key, settings.get(key))
+        if value:
+            cmd.append(flag)
 
     cmd.append(prompt)
     return cmd

--- a/gui_pyside6/backend/settings_manager.py
+++ b/gui_pyside6/backend/settings_manager.py
@@ -8,6 +8,16 @@ SETTINGS_PATH = Path(__file__).resolve().parent.parent / "config" / "settings.js
 DEFAULT_SETTINGS = {
     "temperature": 0.5,
     "max_tokens": 1024,
+    "provider": "openai",
+    "model": "codex-mini-latest",
+    "top_p": 1.0,
+    "frequency_penalty": 0.0,
+    "presence_penalty": 0.0,
+    "approval_mode": "suggest",
+    "auto_edit": False,
+    "full_auto": False,
+    "reasoning": "high",
+    "flex_mode": False,
     "selected_agent": "Python Expert",
     # Optional path to the Codex CLI executable. If empty, the adapter will
     # search the system PATH or use the bundled Node.js script.

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -82,11 +82,15 @@ Key modules:
 | Prompt Editor  | Main text input + response area |
 | Agent Switcher | Choose Codex personalities |
 | Tool Panel     | View/edit Codex-generated files |
-| Settings Dialog| Control temperature, max tokens, runtime env |
+| Settings Dialog| Control temperature, model, provider, penalties and approval modes |
 | Debug Console  | Terminal-style output window (optional) |
 | History Panel  | View past responses and clear them |
 
 All components are modular for future plugins.
+
+The settings dialog also lets you pick the provider and model, adjust top-p,
+frequency/presence penalties, toggle auto-edit or full-auto modes, set the
+reasoning effort, and enable flex mode.
 
 Enable **Verbose Mode** in the settings dialog to print the final CLI command before each run.
 

--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -8,6 +8,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QDoubleSpinBox,
     QSpinBox,
+    QComboBox,
     QLineEdit,
     QPushButton,
     QFileDialog,
@@ -35,11 +36,66 @@ class SettingsDialog(QDialog):
         self.temp_spin.setValue(float(settings.get("temperature", 0.5)))
         layout.addWidget(self.temp_spin)
 
+        layout.addWidget(QLabel("Top-p:"))
+        self.top_p_spin = QDoubleSpinBox()
+        self.top_p_spin.setRange(0.0, 1.0)
+        self.top_p_spin.setSingleStep(0.1)
+        self.top_p_spin.setValue(float(settings.get("top_p", 1.0)))
+        layout.addWidget(self.top_p_spin)
+
+        layout.addWidget(QLabel("Frequency Penalty:"))
+        self.freq_spin = QDoubleSpinBox()
+        self.freq_spin.setRange(-2.0, 2.0)
+        self.freq_spin.setSingleStep(0.1)
+        self.freq_spin.setValue(float(settings.get("frequency_penalty", 0.0)))
+        layout.addWidget(self.freq_spin)
+
+        layout.addWidget(QLabel("Presence Penalty:"))
+        self.presence_spin = QDoubleSpinBox()
+        self.presence_spin.setRange(-2.0, 2.0)
+        self.presence_spin.setSingleStep(0.1)
+        self.presence_spin.setValue(float(settings.get("presence_penalty", 0.0)))
+        layout.addWidget(self.presence_spin)
+
         layout.addWidget(QLabel("Max Tokens:"))
         self.max_spin = QSpinBox()
         self.max_spin.setRange(1, 4096)
         self.max_spin.setValue(int(settings.get("max_tokens", 1024)))
         layout.addWidget(self.max_spin)
+
+        layout.addWidget(QLabel("Provider:"))
+        self.provider_edit = QLineEdit()
+        self.provider_edit.setText(settings.get("provider", "openai"))
+        layout.addWidget(self.provider_edit)
+
+        layout.addWidget(QLabel("Model:"))
+        self.model_edit = QLineEdit()
+        self.model_edit.setText(settings.get("model", "codex-mini-latest"))
+        layout.addWidget(self.model_edit)
+
+        layout.addWidget(QLabel("Approval Mode:"))
+        self.approval_combo = QComboBox()
+        self.approval_combo.addItems(["suggest", "auto-edit", "full-auto"])
+        self.approval_combo.setCurrentText(settings.get("approval_mode", "suggest"))
+        layout.addWidget(self.approval_combo)
+
+        self.auto_edit_check = QCheckBox("Auto Edit")
+        self.auto_edit_check.setChecked(bool(settings.get("auto_edit", False)))
+        layout.addWidget(self.auto_edit_check)
+
+        self.full_auto_check = QCheckBox("Full Auto")
+        self.full_auto_check.setChecked(bool(settings.get("full_auto", False)))
+        layout.addWidget(self.full_auto_check)
+
+        layout.addWidget(QLabel("Reasoning Effort:"))
+        self.reason_combo = QComboBox()
+        self.reason_combo.addItems(["low", "medium", "high"])
+        self.reason_combo.setCurrentText(settings.get("reasoning", "high"))
+        layout.addWidget(self.reason_combo)
+
+        self.flex_check = QCheckBox("Flex Mode")
+        self.flex_check.setChecked(bool(settings.get("flex_mode", False)))
+        layout.addWidget(self.flex_check)
 
         layout.addWidget(QLabel("Codex CLI Path:"))
         cli_row = QWidget()
@@ -64,7 +120,17 @@ class SettingsDialog(QDialog):
 
     def accept(self) -> None:  # type: ignore[override]
         self.settings["temperature"] = float(self.temp_spin.value())
+        self.settings["top_p"] = float(self.top_p_spin.value())
+        self.settings["frequency_penalty"] = float(self.freq_spin.value())
+        self.settings["presence_penalty"] = float(self.presence_spin.value())
         self.settings["max_tokens"] = int(self.max_spin.value())
+        self.settings["provider"] = self.provider_edit.text().strip()
+        self.settings["model"] = self.model_edit.text().strip()
+        self.settings["approval_mode"] = self.approval_combo.currentText()
+        self.settings["auto_edit"] = self.auto_edit_check.isChecked()
+        self.settings["full_auto"] = self.full_auto_check.isChecked()
+        self.settings["reasoning"] = self.reason_combo.currentText()
+        self.settings["flex_mode"] = self.flex_check.isChecked()
         self.settings["cli_path"] = self.cli_edit.text().strip()
         self.settings["verbose"] = self.verbose_check.isChecked()
         save_settings(self.settings)


### PR DESCRIPTION
## Summary
- support more runtime parameters in settings dialog
- save/load provider/model/top-p/frequency/presence/approval/flex settings
- emit CLI flags for new options when starting Codex
- document extended settings

## Testing
- `python -m py_compile gui_pyside6/ui/settings_dialog.py gui_pyside6/backend/settings_manager.py gui_pyside6/backend/codex_adapter.py`

------
https://chatgpt.com/codex/tasks/task_e_684acf6f43f8832985039e80389e5f3c