### PR TITLE
Add session history browsing

### DIFF
--- a/gui_pyside6/backend/codex_adapter.py
+++ b/gui_pyside6/backend/codex_adapter.py
@@ -86,7 +86,12 @@ def ensure_cli_available(settings: dict | None = None) -> None:
         ) from exc
 
 
-def build_command(prompt: str, agent: dict, settings: dict | None = None) -> list[str]:
+def build_command(
+    prompt: str,
+    agent: dict,
+    settings: dict | None = None,
+    view: str | None = None,
+) -> list[str]:
     """Construct the Codex CLI command from agent and settings."""
     settings = settings or {}
 
@@ -132,12 +137,18 @@ def build_command(prompt: str, agent: dict, settings: dict | None = None) -> lis
         if value:
             cmd.append(flag)
 
+    if view:
+        cmd.extend(["--view", view])
+
     cmd.append(prompt)
     return cmd
 
 
 def start_session(
-    prompt: str, agent: dict, settings: dict | None = None
+    prompt: str,
+    agent: dict,
+    settings: dict | None = None,
+    view: str | None = None,
 ) -> Iterable[str]:
     """Start a Codex CLI session with the given prompt and agent.
 
@@ -171,7 +182,7 @@ def start_session(
     if _current_process is not None:
         raise RuntimeError("A Codex session is already running")
 
-    cmd = build_command(prompt, agent, settings)
+    cmd = build_command(prompt, agent, settings, view=view)
     _terminated = False
     process = subprocess.Popen(
         cmd,

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -94,6 +94,13 @@ reasoning effort, and enable flex mode.
 
 Enable **Verbose Mode** in the settings dialog to print the final CLI command before each run.
 
+### Session History
+
+Use **History ▶ Browse Sessions** to open a list of saved sessions from
+`~/.codex/sessions`. Pick a session to **View** its rollout (runs the CLI with
+`--view`) or **Resume** it which inserts the prompt `Resume this session: <file>`
+and starts a new Codex run.
+
 ---
 
 ## 🗺️ IDE Layout

--- a/gui_pyside6/ui/sessions_dialog.py
+++ b/gui_pyside6/ui/sessions_dialog.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QHBoxLayout,
+    QMessageBox,
+)
+
+from ..utils.sessions import SessionMeta
+
+
+class SessionsDialog(QDialog):
+    """Dialog for selecting a past session to view or resume."""
+
+    def __init__(self, sessions: list[SessionMeta], parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Browse Sessions")
+        self.selected_path: str | None = None
+        self.mode: str | None = None  # "view" or "resume"
+
+        layout = QVBoxLayout(self)
+
+        self.list_widget = QListWidget()
+        for s in sessions:
+            ts = ""
+            if s.timestamp:
+                try:
+                    ts = datetime.fromisoformat(s.timestamp).strftime("%Y-%m-%d %H:%M")
+                except ValueError:
+                    ts = s.timestamp
+            label = f"{ts} · {s.user_messages} msgs/{s.tool_calls} tools · {s.first_message}"
+            item = QListWidgetItem(label)
+            item.setData(Qt.UserRole, s.path)
+            self.list_widget.addItem(item)
+        layout.addWidget(self.list_widget)
+
+        btn_row = QHBoxLayout()
+        self.view_btn = QPushButton("View")
+        self.resume_btn = QPushButton("Resume")
+        self.close_btn = QPushButton("Close")
+        btn_row.addWidget(self.view_btn)
+        btn_row.addWidget(self.resume_btn)
+        btn_row.addStretch(1)
+        btn_row.addWidget(self.close_btn)
+        layout.addLayout(btn_row)
+
+        self.view_btn.clicked.connect(self.on_view)
+        self.resume_btn.clicked.connect(self.on_resume)
+        self.close_btn.clicked.connect(self.reject)
+
+    def selected_item_path(self) -> str | None:
+        item = self.list_widget.currentItem()
+        return item.data(Qt.UserRole) if item else None
+
+    def on_view(self) -> None:
+        path = self.selected_item_path()
+        if not path:
+            QMessageBox.information(self, "No Selection", "Please select a session.")
+            return
+        self.selected_path = path
+        self.mode = "view"
+        self.accept()
+
+    def on_resume(self) -> None:
+        path = self.selected_item_path()
+        if not path:
+            QMessageBox.information(self, "No Selection", "Please select a session.")
+            return
+        self.selected_path = path
+        self.mode = "resume"
+        self.accept()

--- a/gui_pyside6/utils/sessions.py
+++ b/gui_pyside6/utils/sessions.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+from typing import List
+
+
+@dataclass
+class SessionMeta:
+    path: str
+    timestamp: str
+    user_messages: int
+    tool_calls: int
+    first_message: str
+
+
+def load_sessions() -> List[SessionMeta]:
+    """Load saved sessions from ~/.codex/sessions."""
+    root = Path.home() / ".codex" / "sessions"
+    sessions: List[SessionMeta] = []
+    if not root.exists():
+        return sessions
+
+    for entry in root.glob("*.json"):
+        try:
+            with entry.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except Exception:
+            continue
+        items = data.get("items", [])
+        first_user = next(
+            (i for i in items if i.get("type") == "message" and i.get("role") == "user"),
+            None,
+        )
+        first_text = ""
+        if first_user:
+            content = first_user.get("content") or []
+            if content and isinstance(content, list):
+                part = content[0]
+                if isinstance(part, dict):
+                    first_text = str(part.get("text", "")).replace("\n", " ")[:16]
+        user_messages = sum(
+            1 for i in items if i.get("type") == "message" and i.get("role") == "user"
+        )
+        tool_calls = sum(1 for i in items if i.get("type") == "function_call")
+        timestamp = data.get("session", {}).get("timestamp", "")
+        sessions.append(
+            SessionMeta(
+                path=str(entry),
+                timestamp=timestamp,
+                user_messages=user_messages,
+                tool_calls=tool_calls,
+                first_message=first_text,
+            )
+        )
+    sessions.sort(key=lambda s: s.timestamp, reverse=True)
+    return sessions


### PR DESCRIPTION
## Summary
- support `--view` rollouts via codex_adapter
- add GUI dialog to browse past sessions
- start Codex with selected rollout or resume prompt
- document how to resume sessions

## Testing
- `ruff check gui_pyside6`


------
https://chatgpt.com/codex/tasks/task_e_684ad0f271c083298a93764e1195ce86