### PR TITLE
Add image attachment support with drag & drop

### DIFF
--- a/gui_pyside6/backend/codex_adapter.py
+++ b/gui_pyside6/backend/codex_adapter.py
@@ -91,6 +91,7 @@ def build_command(
     agent: dict,
     settings: dict | None = None,
     view: str | None = None,
+    images: list[str] | None = None,
 ) -> list[str]:
     """Construct the Codex CLI command from agent and settings."""
     settings = settings or {}
@@ -140,6 +141,10 @@ def build_command(
     if view:
         cmd.extend(["--view", view])
 
+    if images:
+        for img in images:
+            cmd.extend(["--image", img])
+
     cmd.append(prompt)
     return cmd
 
@@ -149,6 +154,7 @@ def start_session(
     agent: dict,
     settings: dict | None = None,
     view: str | None = None,
+    images: list[str] | None = None,
 ) -> Iterable[str]:
     """Start a Codex CLI session with the given prompt and agent.
 
@@ -182,7 +188,7 @@ def start_session(
     if _current_process is not None:
         raise RuntimeError("A Codex session is already running")
 
-    cmd = build_command(prompt, agent, settings, view=view)
+    cmd = build_command(prompt, agent, settings, view=view, images=images)
     _terminated = False
     process = subprocess.Popen(
         cmd,

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -85,6 +85,7 @@ Key modules:
 | Settings Dialog| Control temperature, model, provider, penalties and approval modes |
 | Debug Console  | Terminal-style output window (optional) |
 | History Panel  | View past responses and clear them |
+| Images List    | Attach images via drag-and-drop |
 
 All components are modular for future plugins.
 
@@ -100,6 +101,10 @@ Use **History ▶ Browse Sessions** to open a list of saved sessions from
 `~/.codex/sessions`. Pick a session to **View** its rollout (runs the CLI with
 `--view`) or **Resume** it which inserts the prompt `Resume this session: <file>`
 and starts a new Codex run.
+
+### Image Attachments
+
+Drag image files onto the **Images** list or click **Add Image** to attach screenshots or diagrams to your prompt. Selected files are passed to the CLI using the `--image` flag.
 
 ---
 
@@ -180,7 +185,7 @@ Current examples:
 - [ ] Build debug panel (logs, errors, console)
 - [ ] Execution in `uv` sandbox
 - [ ] Plugin manager
-- [ ] Drag-and-drop file attachments
+- [x] Drag-and-drop file attachments
 
 ---
 


### PR DESCRIPTION
## Summary
- allow dropping image files onto the main window
- pass selected image paths via `--image`
- mention attachments in the docs

## Testing
- `python -m py_compile gui_pyside6/ui/main_window.py gui_pyside6/backend/codex_adapter.py`
- `pnpm test`
- `pnpm run lint`
- `pnpm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684ad2f5f9cc83298c3263a59e2847d4