### PR TITLE
Add quiet/full-context flags to GUI

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -24,6 +24,7 @@ This project reimagines the Codex CLI as a desktop application, offering:
 - Runtime settings for temperature, model, provider, penalties and more passed as CLI flags
 - Remembers the last selected agent across restarts
 - Optional verbose mode prints the exact CLI command before execution
+- Quiet mode and full context options mirror the CLI `--quiet` and `--full-context` flags
 - Additional options for provider, model, top-p, frequency and presence penalties,
   approval mode with auto-edit/full-auto toggles, reasoning effort and flex mode
 

--- a/gui_pyside6/backend/codex_adapter.py
+++ b/gui_pyside6/backend/codex_adapter.py
@@ -125,6 +125,8 @@ def build_command(
         "auto_edit": "--auto-edit",
         "full_auto": "--full-auto",
         "flex_mode": "--flex-mode",
+        "quiet": "--quiet",
+        "full_context": "--full-context",
     }
 
     for key, flag in flag_map.items():

--- a/gui_pyside6/backend/settings_manager.py
+++ b/gui_pyside6/backend/settings_manager.py
@@ -18,6 +18,8 @@ DEFAULT_SETTINGS = {
     "full_auto": False,
     "reasoning": "high",
     "flex_mode": False,
+    "quiet": False,
+    "full_context": False,
     "selected_agent": "Python Expert",
     # Optional path to the Codex CLI executable. If empty, the adapter will
     # search the system PATH or use the bundled Node.js script.

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -94,6 +94,7 @@ frequency/presence penalties, toggle auto-edit or full-auto modes, set the
 reasoning effort, and enable flex mode.
 
 Enable **Verbose Mode** in the settings dialog to print the final CLI command before each run.
+Quiet mode suppresses progress output, while **Full Context** sends the entire conversation to the CLI using `--full-context`.
 
 ### Session History
 

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -308,7 +308,16 @@ class MainWindow(QMainWindow):
         self.stop_btn.setEnabled(True)
         self.run_action.setEnabled(False)
         self.stop_action.setEnabled(True)
-        self.status_bar.showMessage("Running Codex session...")
+        msg = "Running Codex session"
+        modes: list[str] = []
+        if self.settings.get("quiet"):
+            modes.append("quiet")
+        if self.settings.get("full_context"):
+            modes.append("full context")
+        if modes:
+            msg += " (" + ", ".join(modes) + ")"
+        msg += "..."
+        self.status_bar.showMessage(msg)
 
     def append_output(self, text: str) -> None:
         cursor = self.output_view.textCursor()

--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -97,6 +97,14 @@ class SettingsDialog(QDialog):
         self.flex_check.setChecked(bool(settings.get("flex_mode", False)))
         layout.addWidget(self.flex_check)
 
+        self.quiet_check = QCheckBox("Quiet Mode")
+        self.quiet_check.setChecked(bool(settings.get("quiet", False)))
+        layout.addWidget(self.quiet_check)
+
+        self.full_context_check = QCheckBox("Full Context")
+        self.full_context_check.setChecked(bool(settings.get("full_context", False)))
+        layout.addWidget(self.full_context_check)
+
         layout.addWidget(QLabel("Codex CLI Path:"))
         cli_row = QWidget()
         cli_layout = QHBoxLayout(cli_row)
@@ -131,6 +139,8 @@ class SettingsDialog(QDialog):
         self.settings["full_auto"] = self.full_auto_check.isChecked()
         self.settings["reasoning"] = self.reason_combo.currentText()
         self.settings["flex_mode"] = self.flex_check.isChecked()
+        self.settings["quiet"] = self.quiet_check.isChecked()
+        self.settings["full_context"] = self.full_context_check.isChecked()
         self.settings["cli_path"] = self.cli_edit.text().strip()
         self.settings["verbose"] = self.verbose_check.isChecked()
         save_settings(self.settings)


### PR DESCRIPTION
## Summary
- expose `--quiet` and `--full-context` as settings checkboxes
- pass those flags through `codex_adapter.build_command`
- show active modes in the status bar while running
- mention new modes in README and docs

## Testing
- `python -m py_compile gui_pyside6/backend/codex_adapter.py gui_pyside6/backend/settings_manager.py gui_pyside6/ui/settings_dialog.py gui_pyside6/ui/main_window.py`
- `ruff check gui_pyside6`

------
https://chatgpt.com/codex/tasks/task_e_684ad4bc07f883298e7acff3eba95975