### PR TITLE
Add tools panel for running scripts

### DIFF
--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -145,12 +145,12 @@ See [`AGENTS.md`](../AGENTS.md) for structure and editing instructions.
 
 Codex-generated scripts are saved to the `/tools/` folder.
 
-When enabled, users can:
-- Preview and edit scripts
-- Execute scripts inside a `uv` or `conda` environment
-- View stdout/stderr from a log panel
+Use the **Tools** button in the main window to open a panel that lists these scripts.
+Select a file and click **Run** to execute it. Standard output and errors appear in
+the panel's log view. Optionally choose a backend name from the drop-down before
+running to trigger `ensure_backend_installed()` for that backend.
 
-Security: No script is run unless the user clicks “Run Tool”.
+Security: No script is run unless the user explicitly clicks **Run**.
 
 ---
 

--- a/gui_pyside6/ui/__init__.py
+++ b/gui_pyside6/ui/__init__.py
@@ -2,5 +2,6 @@
 
 from .main_window import MainWindow
 from .settings_dialog import SettingsDialog
+from .tools_panel import ToolsPanel
 
-__all__ = ["MainWindow", "SettingsDialog"]
+__all__ = ["MainWindow", "SettingsDialog", "ToolsPanel"]

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -26,6 +26,7 @@ from PySide6.QtWidgets import (
 )
 
 from .settings_dialog import SettingsDialog
+from .tools_panel import ToolsPanel
 from ..backend.settings_manager import save_settings
 
 from ..backend import codex_adapter
@@ -211,6 +212,10 @@ class MainWindow(QMainWindow):
         top_bar.addWidget(self.settings_btn)
         self.settings_btn.clicked.connect(self.open_settings_dialog)
 
+        self.tools_btn = QPushButton("Tools")
+        top_bar.addWidget(self.tools_btn)
+        self.tools_btn.clicked.connect(self.open_tools_panel)
+
         images_row = QHBoxLayout()
         center_layout.addLayout(images_row)
         images_row.addWidget(QLabel("Images:"))
@@ -266,7 +271,9 @@ class MainWindow(QMainWindow):
         # Load optional plugins defined in plugins/manifest.json
         load_plugins(self)
 
-    def start_codex(self, prompt: str | None = None, view_path: str | None = None) -> None:
+    def start_codex(
+        self, prompt: str | None = None, view_path: str | None = None
+    ) -> None:
         if self.worker and self.worker.isRunning():
             return
         try:
@@ -275,7 +282,9 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(self, "Codex CLI Missing", str(exc))
             self.status_bar.showMessage(str(exc))
             return
-        prompt_text = prompt if prompt is not None else self.prompt_edit.toPlainText().strip()
+        prompt_text = (
+            prompt if prompt is not None else self.prompt_edit.toPlainText().strip()
+        )
         agent_item = self.agent_list.currentItem()
         agent_name = agent_item.text() if agent_item else ""
         self.agent_manager.set_active_agent(agent_name)
@@ -284,7 +293,9 @@ class MainWindow(QMainWindow):
         agent = self.agent_manager.active_agent or {}
 
         self.output_view.clear()
-        image_paths = [self.image_list.item(i).text() for i in range(self.image_list.count())]
+        image_paths = [
+            self.image_list.item(i).text() for i in range(self.image_list.count())
+        ]
         cmd = codex_adapter.build_command(
             prompt_text,
             agent,
@@ -355,6 +366,10 @@ class MainWindow(QMainWindow):
         dialog.exec()
         self.status_bar.showMessage("Settings updated")
 
+    def open_tools_panel(self) -> None:
+        dialog = ToolsPanel(self)
+        dialog.exec()
+
     def clear_history(self) -> None:
         """Clear the history panel."""
         self.history_view.clear()
@@ -367,7 +382,10 @@ class MainWindow(QMainWindow):
             "Image Files (*.png *.jpg *.jpeg *.gif *.bmp)",
         )
         for path in files:
-            if not any(path == self.image_list.item(i).text() for i in range(self.image_list.count())):
+            if not any(
+                path == self.image_list.item(i).text()
+                for i in range(self.image_list.count())
+            ):
                 self.image_list.addItem(path)
 
     def remove_selected_images(self) -> None:

--- a/gui_pyside6/ui/tools_panel.py
+++ b/gui_pyside6/ui/tools_panel.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QListWidget,
+    QHBoxLayout,
+    QPushButton,
+    QPlainTextEdit,
+    QLabel,
+    QComboBox,
+    QMessageBox,
+)
+
+from ..backend.tool_runner import run_tool_script
+
+
+class ToolsPanel(QDialog):
+    """Dialog listing scripts from the project tools/ directory."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Tools")
+
+        layout = QVBoxLayout(self)
+
+        self.list_widget = QListWidget()
+        layout.addWidget(self.list_widget)
+
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Backend:"))
+        self.backend_combo = QComboBox()
+        self.backend_combo.addItem("(none)", None)
+        for name in self.available_backends():
+            self.backend_combo.addItem(name, name)
+        row.addWidget(self.backend_combo)
+        self.run_btn = QPushButton("Run")
+        self.close_btn = QPushButton("Close")
+        row.addWidget(self.run_btn)
+        row.addWidget(self.close_btn)
+        layout.addLayout(row)
+
+        self.output_view = QPlainTextEdit()
+        self.output_view.setReadOnly(True)
+        layout.addWidget(self.output_view)
+
+        self.run_btn.clicked.connect(self.run_selected)
+        self.close_btn.clicked.connect(self.accept)
+
+        self.load_scripts()
+
+    def tools_dir(self) -> Path:
+        return Path(__file__).resolve().parents[2] / "tools"
+
+    def available_backends(self) -> list[str]:
+        path = (
+            Path(__file__).resolve().parents[1]
+            / "backend"
+            / "backend_requirements.json"
+        )
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            return list(data.keys())
+        except Exception:  # pylint: disable=broad-except
+            return []
+
+    def load_scripts(self) -> None:
+        self.list_widget.clear()
+        tools = self.tools_dir()
+        if tools.exists():
+            for script in sorted(tools.glob("*.py")):
+                self.list_widget.addItem(script.name)
+
+    def run_selected(self) -> None:
+        item = self.list_widget.currentItem()
+        if not item:
+            QMessageBox.information(self, "No Selection", "Please select a script.")
+            return
+        script_path = self.tools_dir() / item.text()
+        backend_name = self.backend_combo.currentData()
+        _, stdout, stderr = run_tool_script(script_path, backend_name=backend_name)
+        self.output_view.clear()
+        if stdout:
+            self.output_view.appendPlainText(stdout)
+        if stderr:
+            self.output_view.appendPlainText(stderr)


### PR DESCRIPTION
## Summary
- add `ToolsPanel` dialog listing scripts under the project `tools/` folder
- open the panel from MainWindow via a new "Tools" button
- execute selected script with optional backend name using `run_tool_script`
- document tool execution workflow in the docs

## Testing
- `ruff check gui_pyside6/ui gui_pyside6/backend gui_pyside6/docs | head`


------
https://chatgpt.com/codex/tasks/task_e_684ad949ca188329bd6a56bbee0d430d