### PR TITLE
Add file context selection feature

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+# Codex GUI Documentation
+
+This project bundles multiple UIs for interacting with the OpenAI Codex CLI. See
+`gui_pyside6/` for the actively developed PySide6 application.
+
+## File Context Feature
+
+The PySide6 GUI automatically scans the current working directory for common
+source files (Python, JS, Rust, etc.) when starting a session. Discovered paths
+are listed in a **Files** panel where additional files can be added or removed.
+Selected files are passed to the Codex CLI using `--file` flags so the model can
+read them for extra context.

--- a/gui_pyside6/backend/codex_adapter.py
+++ b/gui_pyside6/backend/codex_adapter.py
@@ -92,6 +92,7 @@ def build_command(
     settings: dict | None = None,
     view: str | None = None,
     images: list[str] | None = None,
+    files: list[str] | None = None,
 ) -> list[str]:
     """Construct the Codex CLI command from agent and settings."""
     settings = settings or {}
@@ -147,6 +148,10 @@ def build_command(
         for img in images:
             cmd.extend(["--image", img])
 
+    if files:
+        for path in files:
+            cmd.extend(["--file", path])
+
     cmd.append(prompt)
     return cmd
 
@@ -157,6 +162,7 @@ def start_session(
     settings: dict | None = None,
     view: str | None = None,
     images: list[str] | None = None,
+    files: list[str] | None = None,
 ) -> Iterable[str]:
     """Start a Codex CLI session with the given prompt and agent.
 
@@ -173,6 +179,8 @@ def start_session(
         Runtime settings loaded from ``settings_manager``. ``temperature`` and
         ``max_tokens`` from this dictionary will be applied as CLI flags if they
         are not already provided by ``agent``.
+    files: list[str] | None, optional
+        Paths to include via ``--file`` flags.
 
     Yields
     ------
@@ -190,7 +198,14 @@ def start_session(
     if _current_process is not None:
         raise RuntimeError("A Codex session is already running")
 
-    cmd = build_command(prompt, agent, settings, view=view, images=images)
+    cmd = build_command(
+        prompt,
+        agent,
+        settings,
+        view=view,
+        images=images,
+        files=files,
+    )
     _terminated = False
     process = subprocess.Popen(
         cmd,

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -86,6 +86,7 @@ Key modules:
 | Debug Console  | Dockable log viewer for stdout/stderr |
 | History Panel  | View past responses and clear them |
 | Images List    | Attach images via drag-and-drop |
+| Files List     | Choose which project files to pass to Codex |
 
 All components are modular for future plugins.
 
@@ -153,6 +154,18 @@ the panel's log view. Optionally choose a backend name from the drop-down before
 running to trigger `ensure_backend_installed()` for that backend.
 
 Security: No script is run unless the user explicitly clicks **Run**.
+
+---
+
+## 📂 File Context Detection
+
+At startup the GUI scans the current working directory for common source files
+(Python, JavaScript, Rust, etc.). Any discovered paths appear in a **Files** list
+below the image attachments.
+
+Use **Add File** to include additional paths or **Remove** to exclude them.
+When a Codex session is launched these selected files are passed to the CLI via
+`--file` flags so Codex can read them as context.
 
 ---
 

--- a/gui_pyside6/utils/file_scanner.py
+++ b/gui_pyside6/utils/file_scanner.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+# File extensions considered relevant for context
+EXTENSIONS = {
+    '.py', '.js', '.ts', '.tsx', '.jsx', '.c', '.cpp', '.h', '.rs', '.json', '.md', '.txt'
+}
+
+
+def find_source_files(root: Path | str = '.', max_files: int = 50) -> List[str]:
+    """Recursively discover source files under *root*.
+
+    Only files with extensions defined in :data:`EXTENSIONS` are returned.
+    The search stops after ``max_files`` results to avoid scanning huge
+    directories.
+    """
+    root_path = Path(root)
+    files: List[str] = []
+    for path in root_path.rglob('*'):
+        if path.suffix.lower() in EXTENSIONS and path.is_file():
+            files.append(str(path))
+            if len(files) >= max_files:
+                break
+    return files


### PR DESCRIPTION
## Summary
- auto-detect common source files at session start
- let users pick files with new Files list
- pass file paths to Codex via `--file` flag
- document file context detection

## Testing
- `python -m py_compile gui_pyside6/utils/file_scanner.py gui_pyside6/ui/main_window.py gui_pyside6/backend/codex_adapter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684add96bda88329988c49991cf66199