### PR TITLE
Add model selection support

### DIFF
--- a/gui_pyside6/backend/codex_adapter.py
+++ b/gui_pyside6/backend/codex_adapter.py
@@ -101,7 +101,7 @@ def build_command(
     cmd: list[str] = [cli_exe]
 
     def add_flag(flag: str, value: object | None) -> None:
-        if value is not None:
+        if value is not None and str(value) != "":
             cmd.extend([flag, str(value)])
 
     if "temperature" in agent:
@@ -116,7 +116,6 @@ def build_command(
         "top_p": "--top-p",
         "frequency_penalty": "--frequency-penalty",
         "presence_penalty": "--presence-penalty",
-        "model": "--model",
         "provider": "--provider",
         "approval_mode": "--approval-mode",
         "reasoning": "--reasoning",
@@ -135,6 +134,10 @@ def build_command(
             add_flag(flag, agent[key])
         elif key in settings:
             add_flag(flag, settings[key])
+
+    model = agent.get("model", settings.get("model"))
+    if model:
+        cmd.extend(["--model", str(model)])
 
     for key, flag in bool_flags.items():
         value = agent.get(key, settings.get(key))

--- a/gui_pyside6/backend/model_manager.py
+++ b/gui_pyside6/backend/model_manager.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""Helpers for retrieving available models from OpenAI-compatible APIs."""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+from openai import OpenAI, AzureOpenAI
+
+
+def _create_client(provider: str):
+    """Create an OpenAI client for the given provider."""
+    provider = provider.lower()
+    api_key = os.getenv(f"{provider.upper()}_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError(f"No API key configured for provider: {provider}")
+
+    base_url = os.getenv(f"{provider.upper()}_BASE_URL") or os.getenv("OPENAI_BASE_URL")
+
+    headers: dict[str, str] = {}
+    if os.getenv("OPENAI_ORGANIZATION"):
+        headers["OpenAI-Organization"] = os.getenv("OPENAI_ORGANIZATION")
+    if os.getenv("OPENAI_PROJECT"):
+        headers["OpenAI-Project"] = os.getenv("OPENAI_PROJECT")
+
+    timeout_ms = os.getenv("OPENAI_TIMEOUT_MS")
+    timeout = int(timeout_ms) if timeout_ms and timeout_ms.isdigit() else None
+
+    if provider == "azure":
+        api_version = os.getenv("AZURE_OPENAI_API_VERSION", "2025-03-01-preview")
+        return AzureOpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            api_version=api_version,
+            timeout=timeout,
+            default_headers=headers,
+        )
+
+    return OpenAI(
+        api_key=api_key, base_url=base_url, timeout=timeout, default_headers=headers
+    )
+
+
+def get_available_models(provider: str) -> List[str]:
+    """Return a list of model identifiers available for the API key."""
+    client = _create_client(provider)
+    try:
+        result = client.models.list()
+        models: list[str] = []
+        data = getattr(result, "data", result)
+        for model in data:
+            model_id = getattr(model, "id", None)
+            if isinstance(model_id, str):
+                if model_id.startswith("models/"):
+                    model_id = model_id.replace("models/", "")
+                models.append(model_id)
+        models.sort()
+        return models
+    except Exception:
+        return []

--- a/gui_pyside6/ui/agent_editor_dialog.py
+++ b/gui_pyside6/ui/agent_editor_dialog.py
@@ -8,7 +8,6 @@ from PySide6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QVBoxLayout,
-    QHBoxLayout,
     QLabel,
     QLineEdit,
     QPlainTextEdit,
@@ -26,7 +25,9 @@ from ..backend.agent_loader import AGENTS_DIR
 class AgentEditorDialog(QDialog):
     """Dialog for creating or editing agent JSON files."""
 
-    def __init__(self, agent: dict | None = None, parent: QWidget | None = None) -> None:
+    def __init__(
+        self, agent: dict | None = None, parent: QWidget | None = None
+    ) -> None:
         super().__init__(parent)
         self.agent_path: Path | None = None
         data = agent or {}


### PR DESCRIPTION
## Summary
- add `model_manager` to fetch available models from OpenAI using SDK
- replace model line edit in settings with a combo box and refresh capability
- pass chosen model to Codex CLI
- fix unused import in agent editor dialog

## Testing
- `ruff check gui_pyside6/ui/agent_editor_dialog.py gui_pyside6/backend/model_manager.py gui_pyside6/ui/settings_dialog.py gui_pyside6/backend/codex_adapter.py`
- `black gui_pyside6/backend/codex_adapter.py gui_pyside6/ui/settings_dialog.py gui_pyside6/backend/model_manager.py gui_pyside6/ui/agent_editor_dialog.py --check`

------
https://chatgpt.com/codex/tasks/task_e_684af26d4cb88329b489b09dd1c8f359