### PR TITLE
Add prompt file path completion

### DIFF
--- a/gui_pyside6/utils/project_paths.py
+++ b/gui_pyside6/utils/project_paths.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from .file_scanner import find_source_files
+
+
+def get_common_paths(root: Path | str = Path.cwd(), max_files: int = 50) -> List[str]:
+    """Return source file paths relative to *root* for autocompletion."""
+
+    root_path = Path(root)
+    files: List[str] = []
+    for path in find_source_files(root_path, max_files=max_files):
+        try:
+            rel = Path(path).resolve().relative_to(root_path.resolve())
+        except ValueError:
+            rel = Path(path)
+        files.append(str(rel))
+    return files


### PR DESCRIPTION
## Summary
- helper `get_common_paths` lists relevant project files
- support path completion in prompt editor triggered by `--file` or Ctrl+Space

## Testing
- `python -m py_compile gui_pyside6/utils/project_paths.py gui_pyside6/ui/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_684af86a1a0483298061480ad4aa6813