### PR TITLE
Fix debug console toggle

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -237,7 +237,8 @@ class MainWindow(QMainWindow):
         toggle_console_action = QAction("Debug Console", self)
         toggle_console_action.setCheckable(True)
         toggle_console_action.setChecked(True)
-        toggle_console_action.triggered.connect(self.debug_console.setVisible)
+        toggle_console_action.toggled.connect(self.debug_console.setVisible)
+        self.debug_console.visibilityChanged.connect(toggle_console_action.setChecked)
         view_menu.addAction(toggle_console_action)
 
         clear_history_action = QAction("Clear History", self)


### PR DESCRIPTION
## Summary
- ensure Debug Console action uses `toggled` signal
- keep menu item state in sync with the dock visibility

## Testing
- `python -m py_compile gui_pyside6/ui/main_window.py`
- `./gui_pyside6/run_pyside6.sh --help` *(fails: No virtual environment found)*

------
https://chatgpt.com/codex/tasks/task_e_684afb6041b08329b0e19f38f33ecf3e