### PR TITLE
Update GUI README on CLI build

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -47,6 +47,8 @@ node bin/codex.js --help
 
 If the command fails, install dependencies and build the CLI using `pnpm install && pnpm build`.
 
+Codex CLI is a Node/TypeScript project that must be built once with `pnpm build` before it can be used. The GUI relies on this built CLI.
+
 ## 📦 Installation
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify in the PySide6 README that the Codex CLI is a Node/TypeScript project and must be built once

## Testing
- `python3 scripts/asciicheck.py gui_pyside6/README.md` *(fails: invalid characters)*

------
https://chatgpt.com/codex/tasks/task_e_684afcd4f1008329843d4f05d05fb4df