### PR TITLE
Update docs with new View menu controls

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -26,6 +26,7 @@ This project reimagines the Codex CLI as a desktop application, offering:
 - Optional verbose mode prints the exact CLI command before execution
 - Quiet mode hides progress output while Full Context sends the entire conversation. Both map to the CLI flags `--quiet` and `--full-context`
 - Dockable **Debug Console** shows stdout/stderr from Codex and tool runs
+- Show or hide the left and right panels, or the Debug Console, from the **View** menu
 
 Quiet and full context can be toggled from the **Settings** dialog.
 Example snippet:

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -126,8 +126,9 @@ The main window uses a horizontal splitter:
 Run and Stop actions appear in both a toolbar at the top and a button bar below
 the editor. The bottom status bar shows the active agent and session updates.
 If the CLI fails, its stderr messages are printed in the output panel.
-Detailed stdout and stderr are also routed to the **Debug Console**, which you
-can toggle from the **View** menu and filter by errors or info.
+Detailed stdout and stderr are also routed to the **Debug Console**.
+Both the left and right panels as well as the console can be shown or hidden via
+the **View** menu, and the console lets you filter by errors or info.
 
 ---
 


### PR DESCRIPTION
## Summary
- document View menu toggles for left/right panels and Debug Console
- note these UI controls in README

## Testing
- `pnpm run format`
- `pnpm run lint` *(fails: ESLint config missing)*
- `pnpm run test` *(fails: vitest not found)*
- `pnpm run build` *(fails: cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_684afe8a9f588329a8eeae8751de4a8d