### PR TITLE
Fix panel toggles creation order

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -238,18 +238,6 @@ class MainWindow(QMainWindow):
         self.debug_console.visibilityChanged.connect(toggle_console_action.setChecked)
         view_menu.addAction(toggle_console_action)
 
-        toggle_left_panel_action = QAction("Left Panel", self)
-        toggle_left_panel_action.setCheckable(True)
-        toggle_left_panel_action.setChecked(True)
-        toggle_left_panel_action.toggled.connect(self.left_panel.setVisible)
-        view_menu.addAction(toggle_left_panel_action)
-
-        toggle_right_panel_action = QAction("Right Panel", self)
-        toggle_right_panel_action.setCheckable(True)
-        toggle_right_panel_action.setChecked(True)
-        toggle_right_panel_action.toggled.connect(self.history_view.setVisible)
-        view_menu.addAction(toggle_right_panel_action)
-
         clear_history_action = QAction("Clear History", self)
         clear_history_action.triggered.connect(self.clear_history)
         history_menu.addAction(clear_history_action)
@@ -393,6 +381,18 @@ class MainWindow(QMainWindow):
         splitter.addWidget(self.history_view)
 
         splitter.setStretchFactor(1, 1)
+
+        toggle_left_panel_action = QAction("Left Panel", self)
+        toggle_left_panel_action.setCheckable(True)
+        toggle_left_panel_action.setChecked(True)
+        toggle_left_panel_action.toggled.connect(self.left_panel.setVisible)
+        view_menu.addAction(toggle_left_panel_action)
+
+        toggle_right_panel_action = QAction("Right Panel", self)
+        toggle_right_panel_action.setCheckable(True)
+        toggle_right_panel_action.setChecked(True)
+        toggle_right_panel_action.toggled.connect(self.history_view.setVisible)
+        view_menu.addAction(toggle_right_panel_action)
 
         # Load optional plugins defined in plugins/manifest.json
         load_plugins(self)


### PR DESCRIPTION
## Summary
- create `left_panel` and `history_view` before wiring up View menu actions
- move toggle actions to after the widgets exist

## Testing
- `ruff check gui_pyside6/ui/main_window.py`
- `black --check gui_pyside6/ui/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_684b1633785c832997244423b26dd285