### PR TITLE
Add API key check helper for Hybrid GUI

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -69,7 +69,7 @@ then launches the GUI in a separate terminal window.
 
 1. Run `./run_pyside6.sh` (Windows: `run_pyside6.bat`).
 2. The script installs **Codex CLI** automatically with `npm install -g @openai/codex` if it is not already present.
-3. On first launch the GUI prompts for your OpenAI API key unless `OPENAI_API_KEY` is set.
+3. The GUI prompts for your OpenAI API key the first time you run a session or refresh models if `OPENAI_API_KEY` is not set.
 
 To set the key manually in your shell:
 

--- a/gui_pyside6/main.py
+++ b/gui_pyside6/main.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import sys
-import os
 from PySide6.QtWidgets import (
     QApplication,
     QDialog,
@@ -48,14 +47,6 @@ class ApiKeyDialog(QDialog):
 def main() -> None:
     """Entry point for the Hybrid PySide6 GUI."""
     app = QApplication(sys.argv)
-
-    if "OPENAI_API_KEY" not in os.environ:
-        dialog = ApiKeyDialog()
-        if dialog.exec() == QDialog.Accepted:
-            os.environ["OPENAI_API_KEY"] = dialog.api_key()
-        else:
-            print("Error: OPENAI_API_KEY is required", file=sys.stderr)
-            sys.exit(1)
 
     settings = load_settings()
     agent_manager = AgentManager()

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -40,6 +40,7 @@ from ..plugins.loader import load_plugins
 from ..utils.highlighter import PythonHighlighter
 from ..utils.file_scanner import find_source_files
 from ..utils.project_paths import get_common_paths
+from ..utils.api_key import ensure_api_key
 from pathlib import Path
 
 
@@ -409,6 +410,10 @@ class MainWindow(QMainWindow):
             self.status_bar.showMessage(str(exc))
             self.debug_console.append_error(str(exc))
             return
+        provider = self.settings.get("provider", "openai")
+        if provider not in {"local", "custom"}:
+            if not ensure_api_key(provider, self):
+                return
         prompt_text = (
             prompt if prompt is not None else self.prompt_edit.toPlainText().strip()
         )

--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (
 
 from ..backend.settings_manager import save_settings
 from ..backend.model_manager import get_available_models
+from ..utils.api_key import ensure_api_key
 
 
 class SettingsDialog(QDialog):
@@ -184,6 +185,10 @@ class SettingsDialog(QDialog):
     def load_models(self) -> None:
         """Populate the model combo box based on the selected provider."""
         provider = self.provider_combo.currentData() or "openai"
+        if provider not in {"local", "custom"}:
+            if not ensure_api_key(provider, self):
+                self.model_combo.clear()
+                return
         if provider == "openai":
             try:
                 models = get_available_models(provider)

--- a/gui_pyside6/utils/api_key.py
+++ b/gui_pyside6/utils/api_key.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+from PySide6.QtWidgets import QWidget, QDialog
+
+from ..main import ApiKeyDialog
+
+
+def ensure_api_key(provider: str, parent: QWidget | None = None) -> bool:
+    """Ensure an API key is available for *provider*.
+
+    Checks ``<PROVIDER>_API_KEY`` then ``OPENAI_API_KEY``. If neither is set,
+    an :class:`ApiKeyDialog` is shown. The entered key is stored in the
+    environment. Returns ``True`` when a key is available, ``False`` if the
+    dialog was cancelled.
+    """
+
+    provider = provider.lower()
+    env_var = f"{provider.upper()}_API_KEY"
+    api_key = os.getenv(env_var) or os.getenv("OPENAI_API_KEY")
+    if api_key:
+        return True
+
+    dialog = ApiKeyDialog(parent)
+    if dialog.exec() == QDialog.Accepted:
+        key = dialog.api_key()
+        if key:
+            os.environ[env_var] = key
+            if provider == "openai":
+                os.environ.setdefault("OPENAI_API_KEY", key)
+            return True
+    return False


### PR DESCRIPTION
## Summary
- prompt user for API key only when required
- add `utils/api_key.ensure_api_key` helper
- integrate helper in settings dialog and Codex runner
- document updated behaviour

## Testing
- `ruff check gui_pyside6`

------
https://chatgpt.com/codex/tasks/task_e_684b175d7330832980633f1c2b8d6b0d