### PR TITLE
Add docs for help menu, debug console and plugin manager

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -79,6 +79,17 @@ export OPENAI_API_KEY="sk-your-key"
 set OPENAI_API_KEY=sk-your-key
 ```
 
+## Login & Free Credits
+
+Under the **Help** menu you can run two useful commands:
+
+- **Login** – launches `codex --login` and opens a browser window to authenticate
+  your OpenAI account.
+- **Redeem Free Credits** – runs `codex --free` to claim any promotional credits
+  that may be available.
+
+The command output is shown in the main panel and logged in the Debug Console.
+
 ---
 
 ## Project Structure
@@ -124,6 +135,13 @@ editor. The status bar reports which agent is active and session progress.
 If the Codex CLI encounters an error, its stderr output will appear in the output panel.
 Detailed logs from Codex and tool executions are also sent to the dockable **Debug Console** accessible from the **View** menu.
 
+## Debug Console
+
+The console is a dockable pane that captures stdout and stderr from Codex and
+any running tools. Toggle it from **View → Debug Console**. The window offers
+**Info** and **Errors** checkboxes to filter messages and a **Clear** button to
+reset the log.
+
 ## Docs
 
 For agent presets, architecture decisions, and developer info, see:
@@ -145,6 +163,12 @@ Example plugins included:
 - **TTS Player** - speaks the current prompt using gTTS (disabled by default).
 
 Some plugins rely on optional TTS backends. These dependencies are installed on demand via `ensure_backend_installed()` which detects your active virtual environment or falls back to `~/.hybrid_tts/venv`.
+
+## Plugin Manager
+
+Use **Plugins → Plugin Manager** to enable or disable optional plugins from the
+GUI. The dialog lists each entry from `plugins/manifest.json` with a checkbox.
+Click **Save** to persist your selection and reload the plugins immediately.
 
 ## FAQ
 

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -168,6 +168,27 @@ When a Codex session is launched these selected files are passed to the CLI via
 
 ---
 
+## Login & Free Credits
+
+The **Help** menu provides two account actions:
+
+- **Login** – runs `codex --login` and opens your browser so you can authenticate
+  with your OpenAI account.
+- **Redeem Free Credits** – runs `codex --free` to claim any promotional credits
+  tied to your account.
+
+Command output appears in the main panel and is also logged in the Debug Console.
+
+---
+
+## Debug Console
+
+The Debug Console is a dockable window that shows stdout and stderr from Codex
+and tools. Toggle it from **View → Debug Console**. Use the **Info** and
+**Errors** checkboxes to filter messages and click **Clear** to wipe the log.
+
+---
+
 ## Planned Plugin/Extension Support
 
 Planned plugin architecture will allow:
@@ -192,7 +213,13 @@ Current examples:
 - **Agents**: Drop a JSON file into `resources/agents/`. New files are loaded on startup.
 - **Plugins**: Place your module inside `gui_pyside6/plugins/` and list it in `plugins/manifest.json`. Only entries with `"enabled": true` are imported.
 - **Interface**: Each plugin exports a `register(window)` function which receives the main window instance so you can add widgets or hook signals.
-- Some plugins require additional packages. The helper `ensure_backend_installed()` first checks if you are running inside a virtual environment. If not, it creates a user-scoped environment at `~/.hybrid_tts/venv` (Windows: `%USERPROFILE%\.hybrid_tts\venv`) and installs the dependencies there. Activate your own virtual environment before launching the app if you want packages to be installed elsewhere.
+  - Some plugins require additional packages. The helper `ensure_backend_installed()` first checks if you are running inside a virtual environment. If not, it creates a user-scoped environment at `~/.hybrid_tts/venv` (Windows: `%USERPROFILE%\.hybrid_tts\venv`) and installs the dependencies there. Activate your own virtual environment before launching the app if you want packages to be installed elsewhere.
+
+---
+
+## Plugin Manager
+
+Open **Plugins → Plugin Manager** to enable or disable optional plugins listed in `plugins/manifest.json`. Each entry appears with a checkbox. Click **Save** to persist your choices and reload the plugins immediately.
 
 ---
 


### PR DESCRIPTION
## Summary
- document Login and Redeem Free Credits actions
- describe the Debug Console in more detail
- add instructions for using the Plugin Manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b19c72f0883299a27b3d3740c7349