### PR TITLE
Fix environment path in Windows launcher

### DIFF
--- a/gui_pyside6/run_pyside6.bat
+++ b/gui_pyside6/run_pyside6.bat
@@ -3,9 +3,8 @@ setlocal enabledelayedexpansion
 
 :: Paths
 set "SCRIPT_DIR=%~dp0"
-set "VENV_DIR=%REPO_ROOT%\.venv"
-set "REQ_FILE=%SCRIPT_DIR%requirements.uv.in"
 for %%I in ("%SCRIPT_DIR%..") do set "REPO_ROOT=%%~fI"
+set "REQ_FILE=%SCRIPT_DIR%requirements.uv.in"
 
 echo ======================================================
 echo  Codex GUI Launcher - Environment Setup Assistant


### PR DESCRIPTION
## Summary
- fix REPO_ROOT detection order in `run_pyside6.bat`
- remove unused early `VENV_DIR` assignment

## Testing
- `python scripts/asciicheck.py gui_pyside6/run_pyside6.bat gui_pyside6/run_pyside6.sh`
- `bash gui_pyside6/run_pyside6.sh --help` *(fails: Unable to find the global bin directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b3f381b3883299ed7973b58ec2fec