### PR TITLE
Fix environment path in Windows launcher

### DIFF
--- a/gui_pyside6/run_pyside6.bat
+++ b/gui_pyside6/run_pyside6.bat
@@ -3,9 +3,8 @@ setlocal enabledelayedexpansion
 
 :: Paths
 set "SCRIPT_DIR=%~dp0"
-set "VENV_DIR=%REPO_ROOT%\.venv"
-set "REQ_FILE=%SCRIPT_DIR%requirements.uv.in"
 for %%I in ("%SCRIPT_DIR%..") do set "REPO_ROOT=%%~fI"
+set "REQ_FILE=%SCRIPT_DIR%requirements.uv.in"
 
 echo ======================================================
 echo  Codex GUI Launcher - Environment Setup Assistant
@@ -98,6 +97,8 @@ if not exist "%VENV_DIR%" (
         py -3.11 -m venv "%VENV_DIR%"
     )
 )
+
+"%VENV_DIR%\Scripts\python.exe" -m ensurepip --upgrade >nul 2>&1
 
 :: Sanity check for pip.exe
 if not exist "%VENV_DIR%\Scripts\pip.exe" (

--- a/gui_pyside6/run_pyside6.sh
+++ b/gui_pyside6/run_pyside6.sh
@@ -36,6 +36,7 @@ else
     if [ ! -d "$VENV_DIR" ]; then
         python3 -m venv "$VENV_DIR"
     fi
+    "$VENV_DIR/bin/python3" -m ensurepip --upgrade >/dev/null
     "$VENV_DIR/bin/pip" install -U pip uv >/dev/null
     "$VENV_DIR/bin/uv" pip install -r "$REQ_FILE"
     PYTHON_CMD="$VENV_DIR/bin/python3"


### PR DESCRIPTION
## Summary
- ensure pip is installed for the hybrid GUI virtualenv

## Testing
- `python scripts/asciicheck.py gui_pyside6/run_pyside6.bat gui_pyside6/run_pyside6.sh`
- `bash gui_pyside6/run_pyside6.sh --help` *(fails: Unable to find the global bin directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b3f381b3883299ed7973b58ec2fec