### PR TITLE
Fix requirements install in Windows launcher

### DIFF
--- a/gui_pyside6/run_pyside6.bat
+++ b/gui_pyside6/run_pyside6.bat
@@ -101,16 +101,12 @@ if not exist "%VENV_DIR%" (
 
 "%VENV_DIR%\Scripts\python.exe" -m ensurepip --upgrade >nul 2>&1
 
-:: Update pip and install requirements
+:: Update pip and install uv
 echo Updating pip...
-"%VENV_DIR%\Scripts\python.exe" -m pip install -U pip >nul
+"%VENV_DIR%\Scripts\python.exe" -m pip install -U pip uv >nul
 
 echo Installing requirements...
-if defined UV_BIN (
-    "%UV_BIN%" pip install -r "%REQ_FILE%"
-) else (
-    "%VENV_DIR%\Scripts\python.exe" -m pip install -r "%REQ_FILE%"
-)
+"%VENV_DIR%\Scripts\uv.exe" pip install -r "%REQ_FILE%"
 
 set "PYTHON_CMD=%VENV_DIR%\Scripts\python.exe"
 


### PR DESCRIPTION
## Summary
- update Windows launcher to install UV in the virtual environment
- use the venv's `uv.exe` to install requirements

## Testing
- `ruff check gui_pyside6`

------
https://chatgpt.com/codex/tasks/task_e_684b4a083f6883299c7f553265329087