### PR TITLE
Fix circular import in Hybrid GUI

### DIFF
--- a/gui_pyside6/main.py
+++ b/gui_pyside6/main.py
@@ -1,48 +1,11 @@
 from __future__ import annotations
 
 import sys
-from PySide6.QtWidgets import (
-    QApplication,
-    QDialog,
-    QVBoxLayout,
-    QLabel,
-    QLineEdit,
-    QPushButton,
-)
+from PySide6.QtWidgets import QApplication
 
 from .backend.settings_manager import load_settings
 from .backend.agent_manager import AgentManager
-from .ui import MainWindow
-
-
-class ApiKeyDialog(QDialog):
-    """Simple dialog to request an OpenAI API key from the user."""
-
-    def __init__(self, parent: QDialog | None = None) -> None:
-        super().__init__(parent)
-        self.setWindowTitle("Enter OpenAI API Key")
-
-        layout = QVBoxLayout(self)
-        layout.addWidget(QLabel("Please enter your OpenAI API key:"))
-
-        self.key_edit = QLineEdit()
-        self.key_edit.setEchoMode(QLineEdit.Password)
-        layout.addWidget(self.key_edit)
-
-        button_layout = QVBoxLayout()
-        self.ok_button = QPushButton("OK")
-        self.cancel_button = QPushButton("Cancel")
-        button_layout.addWidget(self.ok_button)
-        button_layout.addWidget(self.cancel_button)
-        layout.addLayout(button_layout)
-
-        self.ok_button.clicked.connect(self.accept)
-        self.cancel_button.clicked.connect(self.reject)
-
-    def api_key(self) -> str:
-        """Return the text entered by the user."""
-        return self.key_edit.text().strip()
-
+from .ui import ApiKeyDialog, MainWindow
 
 def main() -> None:
     """Entry point for the Hybrid PySide6 GUI."""

--- a/gui_pyside6/ui/__init__.py
+++ b/gui_pyside6/ui/__init__.py
@@ -5,6 +5,7 @@ from .settings_dialog import SettingsDialog
 from .tools_panel import ToolsPanel
 from .plugin_manager_dialog import PluginManagerDialog
 from .agent_editor_dialog import AgentEditorDialog
+from .api_key_dialog import ApiKeyDialog
 
 __all__ = [
     "MainWindow",
@@ -12,4 +13,5 @@ __all__ = [
     "ToolsPanel",
     "PluginManagerDialog",
     "AgentEditorDialog",
+    "ApiKeyDialog",
 ]

--- a/gui_pyside6/ui/api_key_dialog.py
+++ b/gui_pyside6/ui/api_key_dialog.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton
+
+
+class ApiKeyDialog(QDialog):
+    """Dialog to request an OpenAI API key from the user."""
+
+    def __init__(self, parent: QDialog | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Enter OpenAI API Key")
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Please enter your OpenAI API key:"))
+
+        self.key_edit = QLineEdit()
+        self.key_edit.setEchoMode(QLineEdit.Password)
+        layout.addWidget(self.key_edit)
+
+        button_layout = QVBoxLayout()
+        self.ok_button = QPushButton("OK")
+        self.cancel_button = QPushButton("Cancel")
+        button_layout.addWidget(self.ok_button)
+        button_layout.addWidget(self.cancel_button)
+        layout.addLayout(button_layout)
+
+        self.ok_button.clicked.connect(self.accept)
+        self.cancel_button.clicked.connect(self.reject)
+
+    def api_key(self) -> str:
+        """Return the entered API key."""
+        return self.key_edit.text().strip()

--- a/gui_pyside6/utils/api_key.py
+++ b/gui_pyside6/utils/api_key.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from PySide6.QtWidgets import QWidget, QDialog
 
-from ..main import ApiKeyDialog
+from ..ui.api_key_dialog import ApiKeyDialog
 
 
 def ensure_api_key(provider: str, parent: QWidget | None = None) -> bool:


### PR DESCRIPTION
## Summary
- move `ApiKeyDialog` to dedicated module
- update imports to avoid circular dependency

## Testing
- `pnpm install`
- `pnpm test`
- `pnpm run lint`
- `pnpm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684b4d7c94b883298be24b46b8420350