### PR TITLE
Improve Codex CLI detection

### DIFF
--- a/gui_pyside6/run_pyside6.bat
+++ b/gui_pyside6/run_pyside6.bat
@@ -128,6 +128,16 @@ set "PYTHON_CMD=%VENV_DIR%\Scripts\python.exe"
 :: STEP 4: Codex CLI Check & Install
 echo.
 echo [Step 4] Checking for Codex CLI...
+
+if "%PKG_MGR%"=="pnpm" (
+    for /f "delims=" %%I in ('pnpm bin -g 2^>nul') do set "PNPM_BIN_DIR=%%I"
+    if defined PNPM_BIN_DIR (
+        if exist "%PNPM_BIN_DIR%\codex.cmd" (
+            set "PATH=%PNPM_BIN_DIR%;%PATH%"
+        )
+    )
+)
+
 where codex >nul 2>&1
 if errorlevel 1 (
     echo Codex CLI not found. Attempting global install using %PKG_MGR%...

--- a/gui_pyside6/run_pyside6.sh
+++ b/gui_pyside6/run_pyside6.sh
@@ -20,12 +20,16 @@ fi
 # Determine package manager (pnpm preferred)
 if command -v pnpm >/dev/null 2>&1; then
     PKG_MGR="pnpm"
+    PNPM_BIN_DIR="$(pnpm bin -g 2>/dev/null || true)"
+    if [ -n "$PNPM_BIN_DIR" ] && [ -x "$PNPM_BIN_DIR/codex" ]; then
+        export PATH="$PNPM_BIN_DIR:$PATH"
+    fi
 else
     PKG_MGR="npm"
 fi
 
-# Ensure the Codex CLI is installed
-if ! codex --help >/dev/null 2>&1; then
+# Ensure the Codex CLI is installed only if missing
+if ! command -v codex >/dev/null 2>&1; then
     echo "Installing @openai/codex globally using $PKG_MGR..."
     $PKG_MGR install -g @openai/codex
 fi


### PR DESCRIPTION
## Summary
- update launcher logic to detect pnpm global bin directory
- add codex bin directory to PATH if present
- install Codex CLI only when missing

## Testing
- `pnpm test && pnpm run lint && pnpm run typecheck` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b599bc80c83299d63d6932f755ca5