### PR TITLE
Update docs on persistent venv

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -63,7 +63,11 @@ cd codex-gui/gui_pyside6
 Running the script detects an active virtual environment. If none is found, it
 creates `~/.hybrid_tts/venv` (Windows: `%USERPROFILE%\.hybrid_tts\venv`) for
 the optional text-to-speech backends, installs the requirements using `uv`, and
-then launches the GUI in a separate terminal window.
+then launches the GUI in a separate terminal window. This environment persists
+for future runs and a `.deps_installed` file prevents reinstalling packages
+unless `requirements.uv.in` changes. Delete the `~/.hybrid_tts/venv` directory
+to force a fresh setup or edit the `VENV_DIR` variable near the top of
+`run_pyside6.*` if you wish to relocate it.
 
 ## First-Time Setup
 
@@ -176,8 +180,8 @@ Click **Save** to persist your selection and reload the plugins immediately.
 
 When the launcher script doesn't find an active Python virtual environment, it
 initializes one at `~/.hybrid_tts/venv` (or `%USERPROFILE%\.hybrid_tts\venv` on
-Windows) for the optional text-to-speech backends. If you don't plan to use any
-TTS features, you can safely remove this directory.
+Windows) for the optional text-to-speech backends. The folder is reused on every
+launch. Remove it if you want to reclaim space or force a reinstall.
 
 ## Credits
 

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -47,6 +47,12 @@ uv pip install -r requirements.uv.in
 ./run_pyside6.sh  # Windows: run_pyside6.bat
 ```
 
+The launcher creates `~/.hybrid_tts/venv` (Windows: `%USERPROFILE%\.hybrid_tts\venv`)
+on first run if no virtual environment is active and reuses it on subsequent
+launches. Dependencies are only reinstalled when `requirements.uv.in` changes.
+Delete this folder to start fresh or edit the `VENV_DIR` variable in
+`run_pyside6.*` to move it elsewhere.
+
 ---
 
 ## Architecture
@@ -213,7 +219,7 @@ Current examples:
 - **Agents**: Drop a JSON file into `resources/agents/`. New files are loaded on startup.
 - **Plugins**: Place your module inside `gui_pyside6/plugins/` and list it in `plugins/manifest.json`. Only entries with `"enabled": true` are imported.
 - **Interface**: Each plugin exports a `register(window)` function which receives the main window instance so you can add widgets or hook signals.
-  - Some plugins require additional packages. The helper `ensure_backend_installed()` first checks if you are running inside a virtual environment. If not, it creates a user-scoped environment at `~/.hybrid_tts/venv` (Windows: `%USERPROFILE%\.hybrid_tts\venv`) and installs the dependencies there. Activate your own virtual environment before launching the app if you want packages to be installed elsewhere.
+  - Some plugins require additional packages. The helper `ensure_backend_installed()` first checks if you are running inside a virtual environment. If not, it creates a user-scoped environment at `~/.hybrid_tts/venv` (Windows: `%USERPROFILE%\.hybrid_tts\venv`) and installs the dependencies there. This directory is reused across launches. Activate your own virtual environment before starting the app if you want packages installed elsewhere.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that `run_pyside6.*` creates `~/.hybrid_tts/venv` on first launch
- note reuse of that venv and how to remove or relocate it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b67647e708329895b19e24fd77ea1