### PR TITLE
Update docs for Node requirement

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -40,6 +40,7 @@ self.full_context_check = QCheckBox("Full Context")
 ## Prerequisites
 
 - Python 3.9 or newer
+- Node.js **22+** installed and on your `PATH`
 - A built copy of **Codex CLI**. From the `codex-cli` directory run:
 
 ```bash

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -39,8 +39,9 @@ Codex-GUI is designed for developers who want a more interactive experience with
 ## Launching {#launching}
 
 1. Install [`uv`](https://github.com/astral-sh/uv).
-2. Verify the **Codex CLI** is built by running `node bin/codex.js --help` in the `codex-cli` directory. If it fails, run `pnpm install && pnpm build` there.
-3. From the `gui_pyside6` folder run:
+2. Ensure Node.js **22+** is installed and available on your `PATH`.
+3. Verify the **Codex CLI** is built by running `node bin/codex.js --help` in the `codex-cli` directory. If it fails, run `pnpm install && pnpm build` there.
+4. From the `gui_pyside6` folder run:
 
 ```bash
 uv pip install -r requirements.uv.in


### PR DESCRIPTION
## Summary
- mention Node.js 22+ requirement in gui_pyside6 README prerequisites
- add Node.js 22+ note to the Launching section of gui_pyside6 docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b6c73259c8329b0f514788430a7db