### PR TITLE
Update docs for provider-specific key and installer retry

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -100,9 +100,10 @@ to force a fresh setup or edit the `VENV_DIR` variable near the top of
 
 1. Run `./run_pyside6.sh` (Windows: `run_pyside6.bat`).
 2. The script installs **Codex CLI** automatically with `npm install -g @openai/codex` if it is not already present.
-3. The GUI prompts for your OpenAI API key the first time you run a session or refresh models if `OPENAI_API_KEY` is not set.
+3. On Windows the installer will retry with `--registry=https://registry.npmmirror.com` if the initial global install fails.
+4. If you choose the **OpenAI** provider, the GUI prompts for an API key the first time you run a session or refresh models when `OPENAI_API_KEY` is not set.
 
-To set the key manually in your shell:
+To set the key manually for the OpenAI provider:
 
 ```bash
 export OPENAI_API_KEY="sk-your-key"
@@ -112,7 +113,7 @@ set OPENAI_API_KEY=sk-your-key
 
 ## Login & Free Credits
 
-Under the **Help** menu you can run two useful commands:
+Under the **Help** menu you can run two useful commands (only needed when using the OpenAI provider):
 
 - **Login** – launches `codex --login` and opens a browser window to authenticate
   your OpenAI account.

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -47,6 +47,7 @@ Codex-GUI is designed for developers who want a more interactive experience with
 uv pip install -r requirements.uv.in
 ./run_pyside6.sh  # Windows: run_pyside6.bat
 ```
+On Windows the batch script will retry the Codex CLI install using `registry.npmmirror.com` if the first attempt fails.
 
 The launcher creates `~/.hybrid_tts/venv` (Windows: `%USERPROFILE%\.hybrid_tts\venv`)
 on first run if no virtual environment is active and reuses it on subsequent
@@ -177,7 +178,7 @@ When a Codex session is launched these selected files are passed to the CLI via
 
 ## Login & Free Credits
 
-The **Help** menu provides two account actions:
+The **Help** menu provides two account actions (relevant when using the OpenAI provider):
 
 - **Login** – runs `codex --login` and opens your browser so you can authenticate
   with your OpenAI account.


### PR DESCRIPTION
## Summary
- clarify that Windows installer retries via npmmirror
- mention OpenAI API key prompt only applies when using the OpenAI provider

## Testing
- `npm run format`
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b6e79b02883298b9fb9fcb408a5e6