### PR TITLE
Update CLI detection

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -41,15 +41,13 @@ self.full_context_check = QCheckBox("Full Context")
 
 - Python 3.9 or newer
 - Node.js **22+** installed and on your `PATH`
-- A built copy of **Codex CLI**. From the `codex-cli` directory run:
+- A working **Codex CLI** installation. Verify by running:
 
 ```bash
-node bin/codex.js --help
+codex --help
 ```
 
-If the command fails, install dependencies and build the CLI using `pnpm install && pnpm build`.
-
-Codex CLI is a Node/TypeScript project that must be built once with `pnpm build` before it can be used. The GUI relies on this built CLI.
+If the command fails, install the CLI globally using `npm install -g @openai/codex`.
 
 ### Package manager detection
 

--- a/gui_pyside6/backend/codex_adapter.py
+++ b/gui_pyside6/backend/codex_adapter.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import subprocess
 import os
 from collections.abc import Iterable
-from pathlib import Path
 
 
 class CodexError(RuntimeError):
@@ -36,10 +35,9 @@ _terminated: bool = False
 def ensure_cli_available(settings: dict | None = None) -> None:
     """Verify that the Codex CLI is accessible.
 
-    The user-configured ``cli_path`` is attempted first. If that fails,
-    the system ``codex`` command and finally the bundled Node.js script are
-    checked. On failure a ``FileNotFoundError`` is raised with a helpful
-    message.
+    The user-configured ``cli_path`` is attempted first. If that fails, the
+    system ``codex`` command is checked. On failure a ``FileNotFoundError`` is
+    raised with a helpful message.
     """
 
     settings = settings or {}
@@ -71,22 +69,10 @@ def ensure_cli_available(settings: dict | None = None) -> None:
     except (FileNotFoundError, subprocess.CalledProcessError):
         pass
 
-    # Fall back to local Node.js script
-    root = Path(__file__).resolve().parents[2]
-    cli_js = root / "codex-cli" / "bin" / "codex.js"
-    try:
-        subprocess.run(
-            ["node", str(cli_js), "--help"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=True,
-            text=True,
-        )
-    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
-        raise FileNotFoundError(
-            "Codex CLI is missing. Run 'pnpm build' in the codex-cli directory "
-            "or add 'codex' to your PATH."
-        ) from exc
+    raise FileNotFoundError(
+        "Codex CLI is missing. Install it globally with 'npm install -g @openai/codex' "
+        "or add 'codex' to your PATH."
+    )
 
 
 def build_command(

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -40,7 +40,7 @@ Codex-GUI is designed for developers who want a more interactive experience with
 
 1. Install [`uv`](https://github.com/astral-sh/uv).
 2. Ensure Node.js **22+** is installed and available on your `PATH`.
-3. Verify the **Codex CLI** is built by running `node bin/codex.js --help` in the `codex-cli` directory. If it fails, run `pnpm install && pnpm build` there.
+3. Verify the **Codex CLI** is available by running `codex --help`. If it fails, install it globally with `npm install -g @openai/codex`.
 4. From the `gui_pyside6` folder run:
 
 ```bash


### PR DESCRIPTION
## Summary
- remove Node.js fallback in codex adapter
- point users to global CLI install
- document new requirement in README and docs

## Testing
- `python -m py_compile gui_pyside6/backend/codex_adapter.py`

------
https://chatgpt.com/codex/tasks/task_e_684b779fbae483298367ee6efb7a8f1f