### PR TITLE
Fix menu ordering

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -187,9 +187,9 @@ class MainWindow(QMainWindow):
         settings_menu = menu_bar.addMenu("Settings")
         plugins_menu = menu_bar.addMenu("Plugins")
         agents_menu = menu_bar.addMenu("Agents")
-        help_menu = menu_bar.addMenu("Help")
         history_menu = menu_bar.addMenu("History")
         view_menu = menu_bar.addMenu("View")
+        help_menu = menu_bar.addMenu("Help")
 
         self.run_action = QAction("Run", self)
         self.run_action.triggered.connect(self.start_codex)


### PR DESCRIPTION
## Summary
- update menu order so Help appears last

## Testing
- `ruff check ui`
- `black --check ui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_684b78eeb7e08329bb5febeceb060bb5