### PR TITLE
Improve CLI detection logging and guidance

### DIFF
--- a/gui_pyside6/backend/codex_adapter.py
+++ b/gui_pyside6/backend/codex_adapter.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import shutil
 from pathlib import Path
-from collections.abc import Iterable
+from collections.abc import Iterable, Callable
 
 from .settings_manager import save_settings
 
@@ -36,7 +36,10 @@ _current_process: subprocess.Popen[str] | None = None
 _terminated: bool = False
 
 
-def ensure_cli_available(settings: dict | None = None) -> None:
+def ensure_cli_available(
+    settings: dict | None = None,
+    log_fn: Callable[[str, str], None] | None = None,
+) -> None:
     """Verify that the Codex CLI is accessible.
 
     The user-configured ``cli_path`` is attempted first. If that fails, the
@@ -74,6 +77,10 @@ def ensure_cli_available(settings: dict | None = None) -> None:
         if candidate:
             candidates.append(candidate)
 
+    if log_fn:
+        paths_txt = ", ".join(candidates) or "<none>"
+        log_fn(f"Searching CLI paths: {paths_txt}", "info")
+
     for path in candidates:
         try:
             subprocess.run(
@@ -94,8 +101,8 @@ def ensure_cli_available(settings: dict | None = None) -> None:
             continue
 
     raise FileNotFoundError(
-        "Codex CLI is missing. Install it globally with 'npm install -g @openai/codex' "
-        "or add 'codex' to your PATH."
+        "Codex CLI is missing. Install it with 'npm install -g @openai/codex' or set the path in Settings. "
+        "See README.md#first-time-setup for manual setup steps."
     )
 
 

--- a/gui_pyside6/main.py
+++ b/gui_pyside6/main.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import QApplication
 
 from .backend.settings_manager import load_settings
 from .backend.agent_manager import AgentManager
-from .ui import ApiKeyDialog, MainWindow
+from .ui import MainWindow
 
 def main() -> None:
     """Entry point for the Hybrid PySide6 GUI."""

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -414,8 +414,14 @@ class MainWindow(QMainWindow):
     ) -> None:
         if self.worker and self.worker.isRunning():
             return
+        def log_fn(text: str, level: str = "info") -> None:
+            if level == "error":
+                self.debug_console.append_error(text)
+            else:
+                self.debug_console.append_info(text)
+
         try:
-            codex_adapter.ensure_cli_available(self.settings)
+            codex_adapter.ensure_cli_available(self.settings, log_fn=log_fn)
         except FileNotFoundError as exc:
             QMessageBox.warning(self, "Codex CLI Missing", str(exc))
             self.status_bar.showMessage(str(exc))
@@ -774,8 +780,14 @@ class MainWindow(QMainWindow):
     def _run_cli_command(self, fn, done_msg: str) -> None:
         if self.worker and self.worker.isRunning():
             return
+        def log_fn(text: str, level: str = "info") -> None:
+            if level == "error":
+                self.debug_console.append_error(text)
+            else:
+                self.debug_console.append_info(text)
+
         try:
-            codex_adapter.ensure_cli_available(self.settings)
+            codex_adapter.ensure_cli_available(self.settings, log_fn=log_fn)
         except FileNotFoundError as exc:
             QMessageBox.warning(self, "Codex CLI Missing", str(exc))
             self.status_bar.showMessage(str(exc))


### PR DESCRIPTION
## Summary
- log CLI search paths in the debug console when checking for codex
- clarify install error message with setup link and CLI path suggestion
- pass debug logger to `ensure_cli_available`
- clean up unused import

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_684b861143208329b17329a38003f677