### PR TITLE
Fix worker cleanup on window close

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -816,3 +816,11 @@ class MainWindow(QMainWindow):
         self.free_action.setEnabled(True)
         self.status_bar.showMessage(msg)
         self.debug_console.append_info(msg)
+        self.worker = None
+
+    def closeEvent(self, event) -> None:  # type: ignore[override]
+        """Handle the window closing."""
+        codex_adapter.stop_session()
+        if self.worker and self.worker.isRunning():
+            self.worker.wait(1000)
+        super().closeEvent(event)


### PR DESCRIPTION
## Summary
- implement `MainWindow.closeEvent` to ensure running sessions are stopped
- clear worker reference when a CLI command finishes

## Testing
- `python -m py_compile gui_pyside6/ui/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_684c1c0fc23c8329a9eed2b888030fdc