### PR TITLE
Ensure CLI command cleanup on startup failure

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -797,7 +797,9 @@ class MainWindow(QMainWindow):
         self.worker = CodexCommandWorker(fn)
         self.worker.line_received.connect(self.append_output)
         self.worker.log_line.connect(self.handle_log_line)
-        self.worker.finished.connect(lambda: self._command_finished(done_msg))
+        self.worker.finished.connect(
+            lambda: self._command_finished(done_msg), Qt.QueuedConnection
+        )
         self.run_btn.setEnabled(False)
         self.run_action.setEnabled(False)
         self.stop_btn.setEnabled(False)


### PR DESCRIPTION
## Summary
- handle Codex CLI failures properly
- queue `_command_finished` slot so menu actions are re-enabled

## Testing
- `ruff check gui_pyside6/ui/main_window.py`
- `python -m compileall gui_pyside6/ui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_684c1cdb7c1c8329ab60594e09043934