### PR TITLE
Implement proper session stop on window close

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -822,7 +822,9 @@ class MainWindow(QMainWindow):
 
     def closeEvent(self, event) -> None:  # type: ignore[override]
         """Handle the window closing."""
-        codex_adapter.stop_session()
         if self.worker and self.worker.isRunning():
-            self.worker.wait(1000)
+            # If a Codex session or command is running, stop it first
+            self.stop_codex()
+            # Ensure the worker thread has fully finished
+            self.worker.wait()
         super().closeEvent(event)


### PR DESCRIPTION
## Summary
- ensure MainWindow waits for running Codex threads when closing

## Testing
- `ruff check gui_pyside6`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c1fa1b84c8329b2cf7f0ca1767870