### PR TITLE
Log ollama commands in settings

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -529,7 +529,7 @@ class MainWindow(QMainWindow):
         self.update_agent_description()
 
     def open_settings_dialog(self) -> None:
-        dialog = SettingsDialog(self.settings, self)
+        dialog = SettingsDialog(self.settings, self, debug_console=self.debug_console)
         dialog.exec()
         self.status_bar.showMessage("Settings updated")
 


### PR DESCRIPTION
## Summary
- allow passing an optional debug console into the settings dialog
- pass `self.debug_console` from the main window when opening settings
- show ollama commands and running models in the debug console when loading local models

## Testing
- `python -m py_compile gui_pyside6/ui/settings_dialog.py gui_pyside6/ui/main_window.py`
- `python -m compileall -q gui_pyside6`

------
https://chatgpt.com/codex/tasks/task_e_684c277167948329afd6ba8117844d08