### PR TITLE
Add API key button in dialog

### DIFF
--- a/gui_pyside6/ui/api_key_dialog.py
+++ b/gui_pyside6/ui/api_key_dialog.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton
+from PySide6.QtGui import QDesktopServices
+from PySide6.QtCore import QUrl
+from PySide6.QtWidgets import (
+    QDialog,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+)
 
 
 class ApiKeyDialog(QDialog):
@@ -16,6 +24,14 @@ class ApiKeyDialog(QDialog):
         self.key_edit = QLineEdit()
         self.key_edit.setEchoMode(QLineEdit.Password)
         layout.addWidget(self.key_edit)
+
+        self.get_key_button = QPushButton("Get API Key")
+        self.get_key_button.clicked.connect(
+            lambda: QDesktopServices.openUrl(
+                QUrl("https://platform.openai.com/account/api-keys")
+            )
+        )
+        layout.addWidget(self.get_key_button)
 
         button_layout = QVBoxLayout()
         self.ok_button = QPushButton("OK")


### PR DESCRIPTION
## Summary
- let users open the OpenAI API key page from the API key dialog

## Testing
- `ruff check gui_pyside6`


------
https://chatgpt.com/codex/tasks/task_e_684c2c3f500c832994113e7d72f9c8d2