### PR TITLE
Update docs for API key link

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -100,6 +100,7 @@ to force a fresh setup or edit the `VENV_DIR` variable near the top of
 2. The script installs **Codex CLI** automatically with `npm install -g @openai/codex` if it is not already present.
 3. On Windows the installer will retry with `--registry=https://registry.npmmirror.com` if the initial global install fails.
 4. If you choose the **OpenAI** provider, the GUI prompts for an API key the first time you run a session or refresh models when `OPENAI_API_KEY` is not set.
+5. The dialog now offers a **Get API Key** link that opens the OpenAI account page so you can quickly generate a new key.
 
 To set the key manually for the OpenAI provider:
 
@@ -117,6 +118,8 @@ Under the **Help** menu you can run two useful commands (only needed when using 
   your OpenAI account.
 - **Redeem Free Credits** - runs `codex --free` to claim any promotional credits
   that may be available.
+
+The API key prompt also provides a **Get API Key** link that opens your account page in a browser.
 
 The command output is shown in the main panel and logged in the Debug Console.
 

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -180,10 +180,12 @@ When a Codex session is launched these selected files are passed to the CLI via
 
 The **Help** menu provides two account actions (relevant when using the OpenAI provider):
 
-- **Login** – runs `codex --login` and opens your browser so you can authenticate
+- **Login** - runs `codex --login` and opens your browser so you can authenticate
   with your OpenAI account.
-- **Redeem Free Credits** – runs `codex --free` to claim any promotional credits
+- **Redeem Free Credits** - runs `codex --free` to claim any promotional credits
   tied to your account.
+
+The API key dialog now includes a **Get API Key** link that opens your OpenAI account page.
 
 Command output appears in the main panel and is also logged in the Debug Console.
 
@@ -192,7 +194,7 @@ Command output appears in the main panel and is also logged in the Debug Console
 ## Debug Console
 
 The Debug Console is a dockable window that shows stdout and stderr from Codex
-and tools. Toggle it from **View → Debug Console**. Use the **Info** and
+and tools. Toggle it from **View -> Debug Console**. Use the **Info** and
 **Errors** checkboxes to filter messages and click **Clear** to wipe the log.
 
 ---
@@ -227,7 +229,7 @@ Current examples:
 
 ## Plugin Manager
 
-Open **Plugins → Plugin Manager** to enable or disable optional plugins listed in `plugins/manifest.json`. Each entry appears with a checkbox. Click **Save** to persist your choices and reload the plugins immediately.
+Open **Plugins -> Plugin Manager** to enable or disable optional plugins listed in `plugins/manifest.json`. Each entry appears with a checkbox. Click **Save** to persist your choices and reload the plugins immediately.
 
 ---
 


### PR DESCRIPTION
## Summary
- document new **Get API Key** link in the first-time setup instructions
- mention the link again in the Login & Free Credits docs

## Testing
- `python3 scripts/asciicheck.py gui_pyside6/README.md gui_pyside6/docs/index.md`
- `pnpm run format`

------
https://chatgpt.com/codex/tasks/task_e_684c2d212454832992b9b1feda6d8796