### PR TITLE
Fix command display with mixed types

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -495,8 +495,8 @@ class MainWindow(QMainWindow):
             cwd=cwd_arg,
         )
         if self.settings.get("verbose"):
-            self.append_output("$ " + " ".join(cmd))
-        self.debug_console.append_info("$ " + " ".join(cmd))
+            self.append_output("$ " + " ".join(map(str, cmd)))
+        self.debug_console.append_info("$ " + " ".join(map(str, cmd)))
         self.worker = CodexWorker(
             prompt_text,
             agent,


### PR DESCRIPTION
## Summary
- ensure command entries are converted to strings before logging
- run lint checks

## Testing
- `ruff check gui_pyside6/ui/main_window.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c39c57fe08329b6e61bfdd00a98bd