### PR TITLE
Add auto scan files setting

### DIFF
--- a/gui_pyside6/backend/settings_manager.py
+++ b/gui_pyside6/backend/settings_manager.py
@@ -31,6 +31,8 @@ DEFAULT_SETTINGS = {
     "no_project_doc": False,
     "disable_response_storage": False,
     "writable_root": "",
+    # Automatically populate the file list with detected source files
+    "auto_scan_files": True,
 }
 
 

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -167,8 +167,9 @@ Security: No script is run unless the user explicitly clicks **Run**.
 ## File Context Detection
 
 At startup the GUI scans the current working directory for common source files
-(Python, JavaScript, Rust, etc.). Any discovered paths appear in a **Files** list
-below the image attachments.
+(Python, JavaScript, Rust, etc.) and automatically populates the **Files** list
+with any matches. This behaviour is controlled by the **Auto Scan Files**
+setting in the Settings dialog.
 
 Use **Add File** to include additional paths or **Remove** to exclude them.
 When a Codex session is launched these selected files are passed to the CLI via

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -477,7 +477,7 @@ class MainWindow(QMainWindow):
         image_paths = [
             self.image_list.item(i).text() for i in range(self.image_list.count())
         ]
-        if self.file_list.count() == 0:
+        if self.settings.get("auto_scan_files", True) and self.file_list.count() == 0:
             for path in self.suggest_source_files():
                 self.file_list.addItem(path)
         file_paths = [

--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -178,6 +178,12 @@ class SettingsDialog(QDialog):
         )
         layout.addWidget(self.disable_storage_check)
 
+        self.auto_scan_check = QCheckBox("Auto Scan Files")
+        self.auto_scan_check.setChecked(
+            bool(settings.get("auto_scan_files", True))
+        )
+        layout.addWidget(self.auto_scan_check)
+
         layout.addWidget(QLabel("Project Doc:"))
         project_doc_row = QWidget()
         project_doc_layout = QHBoxLayout(project_doc_row)
@@ -402,6 +408,7 @@ class SettingsDialog(QDialog):
         )
         self.settings["project_doc"] = self.project_doc_edit.text().strip()
         self.settings["writable_root"] = self.writable_root_edit.text().strip()
+        self.settings["auto_scan_files"] = self.auto_scan_check.isChecked()
         save_settings(self.settings)
         super().accept()
 


### PR DESCRIPTION
## Summary
- add `auto_scan_files` default setting in settings manager
- respect new setting when populating file list
- expose checkbox in settings dialog to toggle scanning
- persist the setting when saved
- document auto scan behaviour in docs

## Testing
- `python -m py_compile gui_pyside6/backend/settings_manager.py gui_pyside6/ui/settings_dialog.py gui_pyside6/ui/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_684c3ae9423483298724ab543d74fdc3