### PR TITLE
Add persistent API key storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ CHANGELOG.ignore.md
 .direnv
 .envrc
 gui_pyside6/.deps_installed
+gui_pyside6/config/api_keys.json

--- a/gui_pyside6/.gitignore
+++ b/gui_pyside6/.gitignore
@@ -11,6 +11,7 @@ uv.lock
 requirements.lock.txt
 settings.json
 manifest.json
+config/api_keys.json
 
 
 # Tools

--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -99,8 +99,8 @@ to force a fresh setup or edit the `VENV_DIR` variable near the top of
 1. Run `./run.sh` (Windows: `run.bat`).
 2. The script installs **Codex CLI** automatically with `npm install -g @openai/codex` if it is not already present.
 3. On Windows the installer will retry with `--registry=https://registry.npmmirror.com` if the initial global install fails.
-4. If you choose the **OpenAI** provider, the GUI prompts for an API key the first time you run a session or refresh models when `OPENAI_API_KEY` is not set.
-5. The dialog now offers a **Get API Key** link that opens the OpenAI account page so you can quickly generate a new key.
+4. If you choose the **OpenAI** provider, the GUI prompts for an API key the first time you run a session or refresh models when `OPENAI_API_KEY` is not set. The dialog includes a **Remember key** checkbox which saves the key in `config/api_keys.json` so you don't need to enter it again.
+5. The prompt also offers a **Get API Key** link that opens the OpenAI account page so you can quickly generate a new key.
 
 To set the key manually for the OpenAI provider:
 

--- a/gui_pyside6/ui/api_key_dialog.py
+++ b/gui_pyside6/ui/api_key_dialog.py
@@ -5,6 +5,7 @@ from PySide6.QtCore import QUrl
 from PySide6.QtWidgets import (
     QDialog,
     QLabel,
+    QCheckBox,
     QLineEdit,
     QPushButton,
     QVBoxLayout,
@@ -24,6 +25,9 @@ class ApiKeyDialog(QDialog):
         self.key_edit = QLineEdit()
         self.key_edit.setEchoMode(QLineEdit.Password)
         layout.addWidget(self.key_edit)
+
+        self.remember_check = QCheckBox("Remember key")
+        layout.addWidget(self.remember_check)
 
         self.get_key_button = QPushButton("Get API Key")
         self.get_key_button.clicked.connect(
@@ -46,3 +50,7 @@ class ApiKeyDialog(QDialog):
     def api_key(self) -> str:
         """Return the entered API key."""
         return self.key_edit.text().strip()
+
+    def remember_key(self) -> bool:
+        """Return ``True`` if the remember checkbox is checked."""
+        return self.remember_check.isChecked()

--- a/gui_pyside6/utils/api_key.py
+++ b/gui_pyside6/utils/api_key.py
@@ -1,23 +1,65 @@
 from __future__ import annotations
 
+import json
 import os
+from pathlib import Path
 from PySide6.QtWidgets import QWidget, QDialog
 
 from ..ui.api_key_dialog import ApiKeyDialog
+
+CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
+KEY_FILE = CONFIG_DIR / "api_keys.json"
+
+
+def _load_keys() -> dict[str, str]:
+    """Return stored provider keys from :data:`KEY_FILE`."""
+    if not KEY_FILE.exists():
+        return {}
+    try:
+        with KEY_FILE.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict):
+            return {k.lower(): str(v) for k, v in data.items()}
+    except Exception:
+        pass
+    return {}
+
+
+def _save_key(provider: str, key: str) -> None:
+    """Persist *key* for *provider*."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    data = _load_keys()
+    data[provider.lower()] = key
+    try:
+        with KEY_FILE.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+    except Exception:
+        pass
 
 
 def ensure_api_key(provider: str, parent: QWidget | None = None) -> bool:
     """Ensure an API key is available for *provider*.
 
-    Checks ``<PROVIDER>_API_KEY`` then ``OPENAI_API_KEY``. If neither is set,
-    an :class:`ApiKeyDialog` is shown. The entered key is stored in the
-    environment. Returns ``True`` when a key is available, ``False`` if the
+    Looks for ``<PROVIDER>_API_KEY`` or ``OPENAI_API_KEY`` in the environment.
+    If not found, tries ``config/api_keys.json`` and sets the variable when a
+    stored key exists. Otherwise an :class:`ApiKeyDialog` is shown. If the user
+    confirms the dialog and chooses to remember the key it will be written to the
+    config file. Returns ``True`` when a key is available, ``False`` if the
     dialog was cancelled.
     """
 
     provider = provider.lower()
     env_var = f"{provider.upper()}_API_KEY"
+
     api_key = os.getenv(env_var) or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        saved = _load_keys().get(provider)
+        if saved:
+            api_key = saved
+            os.environ[env_var] = api_key
+            if provider == "openai":
+                os.environ.setdefault("OPENAI_API_KEY", api_key)
+
     if api_key:
         return True
 
@@ -28,5 +70,7 @@ def ensure_api_key(provider: str, parent: QWidget | None = None) -> bool:
             os.environ[env_var] = key
             if provider == "openai":
                 os.environ.setdefault("OPENAI_API_KEY", key)
+            if dialog.remember_key():
+                _save_key(provider, key)
             return True
     return False


### PR DESCRIPTION
## Summary
- track `gui_pyside6/config/` and add placeholder `.gitkeep`
- exclude `config/api_keys.json` in gitignore
- add `Remember key` checkbox to `ApiKeyDialog`
- remember entered key in new `api_keys.json`
- document new feature in README

## Testing
- `black --check gui_pyside6/utils/api_key.py gui_pyside6/ui/api_key_dialog.py`
- `ruff check gui_pyside6/utils/api_key.py gui_pyside6/ui/api_key_dialog.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3b10fc1c8329889c0d7eb0cfa930