### PR TITLE
Persist settings when closing

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -914,4 +914,5 @@ class MainWindow(QMainWindow):
             self.stop_codex()
             # Ensure the worker thread has fully finished
             self.worker.wait()
+        save_settings(self.settings)
         super().closeEvent(event)


### PR DESCRIPTION
## Summary
- call `save_settings` in `MainWindow.closeEvent` to persist changes on exit

## Testing
- `ruff check gui_pyside6/ui/main_window.py`
- `pyright gui_pyside6/ui/main_window.py` *(fails: numerous Qt attribute access errors)*
- ran a minimal PySide6 script to close the window and verified provider/model saved

------
https://chatgpt.com/codex/tasks/task_e_684c45368ad08329bab6e5eeb026c532