### PR TITLE
Add API key manager dialog

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -101,6 +101,7 @@ to force a fresh setup or edit the `VENV_DIR` variable near the top of
 3. On Windows the installer will retry with `--registry=https://registry.npmmirror.com` if the initial global install fails.
 4. If you choose the **OpenAI** provider, the GUI prompts for an API key the first time you run a session or refresh models when `OPENAI_API_KEY` is not set. The dialog includes a **Remember key** checkbox which saves the key in `config/api_keys.json` so you don't need to enter it again.
 5. The prompt also offers a **Get API Key** link that opens the OpenAI account page so you can quickly generate a new key.
+6. Open **File -> Settings** and click **Manage API Keys** to update or delete saved entries.
 
 To set the key manually for the OpenAI provider:
 

--- a/gui_pyside6/ui/__init__.py
+++ b/gui_pyside6/ui/__init__.py
@@ -6,6 +6,7 @@ from .tools_panel import ToolsPanel
 from .plugin_manager_dialog import PluginManagerDialog
 from .agent_editor_dialog import AgentEditorDialog
 from .api_key_dialog import ApiKeyDialog
+from .api_keys_dialog import ApiKeysDialog
 
 __all__ = [
     "MainWindow",
@@ -14,4 +15,5 @@ __all__ = [
     "PluginManagerDialog",
     "AgentEditorDialog",
     "ApiKeyDialog",
+    "ApiKeysDialog",
 ]

--- a/gui_pyside6/ui/api_keys_dialog.py
+++ b/gui_pyside6/ui/api_keys_dialog.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QHBoxLayout,
+    QMessageBox,
+)
+
+from ..utils.api_key import _load_keys, _save_key, KEY_FILE, CONFIG_DIR
+from .api_key_dialog import ApiKeyDialog
+
+
+class ApiKeysDialog(QDialog):
+    """Dialog for viewing and editing stored API keys."""
+
+    def __init__(self, parent: QDialog | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Manage API Keys")
+        self.keys: dict[str, str] = _load_keys()
+
+        layout = QVBoxLayout(self)
+
+        self.list_widget = QListWidget()
+        layout.addWidget(self.list_widget)
+
+        btn_row = QHBoxLayout()
+        self.update_btn = QPushButton("Update")
+        self.delete_btn = QPushButton("Delete")
+        self.close_btn = QPushButton("Close")
+        btn_row.addWidget(self.update_btn)
+        btn_row.addWidget(self.delete_btn)
+        btn_row.addStretch(1)
+        btn_row.addWidget(self.close_btn)
+        layout.addLayout(btn_row)
+
+        self.update_btn.clicked.connect(self.update_key)
+        self.delete_btn.clicked.connect(self.delete_key)
+        self.close_btn.clicked.connect(self.accept)
+
+        self.refresh_list()
+
+    def refresh_list(self) -> None:
+        self.list_widget.clear()
+        for provider in sorted(self.keys):
+            item = QListWidgetItem(provider)
+            item.setData(Qt.UserRole, provider)
+            self.list_widget.addItem(item)
+
+    def selected_provider(self) -> str | None:
+        item = self.list_widget.currentItem()
+        return item.data(Qt.UserRole) if item else None
+
+    def update_key(self) -> None:
+        provider = self.selected_provider()
+        if not provider:
+            QMessageBox.information(self, "No Selection", "Please select a provider.")
+            return
+        dialog = ApiKeyDialog(self)
+        dialog.setWindowTitle(f"{provider.capitalize()} API Key")
+        dialog.key_edit.setText(self.keys.get(provider, ""))
+        dialog.remember_check.setChecked(True)
+        if dialog.exec() == QDialog.Accepted:
+            key = dialog.api_key()
+            if key:
+                _save_key(provider, key)
+                self.keys[provider] = key
+                self.refresh_list()
+
+    def delete_key(self) -> None:
+        provider = self.selected_provider()
+        if not provider:
+            QMessageBox.information(self, "No Selection", "Please select a provider.")
+            return
+        if (
+            QMessageBox.question(
+                self,
+                "Delete API Key",
+                f"Delete stored key for {provider}?",
+            )
+            != QMessageBox.Yes
+        ):
+            return
+        self.keys.pop(provider, None)
+        try:
+            CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+            with KEY_FILE.open("w", encoding="utf-8") as fh:
+                json.dump(self.keys, fh, indent=2)
+        except Exception as exc:  # pylint: disable=broad-except
+            QMessageBox.warning(self, "Delete Failed", str(exc))
+            return
+        self.refresh_list()

--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -29,6 +29,7 @@ from ..backend.settings_manager import save_settings
 from ..backend.model_manager import get_available_models
 from ..backend import codex_adapter
 from ..utils.api_key import ensure_api_key
+from .api_keys_dialog import ApiKeysDialog
 
 
 class SettingsDialog(QDialog):
@@ -86,18 +87,25 @@ class SettingsDialog(QDialog):
         layout.addWidget(self.max_spin)
 
         layout.addWidget(QLabel("Provider:"))
+        provider_row = QWidget()
+        provider_layout = QHBoxLayout(provider_row)
+        provider_layout.setContentsMargins(0, 0, 0, 0)
         self.provider_combo = QComboBox()
         self.provider_combo.addItem("OpenAI (Codex)", "openai")
         self.provider_combo.addItem("Local", "local")
         self.provider_combo.addItem("Custom", "custom")
+        self.manage_keys_btn = QPushButton("Manage API Keys")
         current_provider = settings.get("provider", "openai")
         index = self.provider_combo.findData(current_provider)
         if index >= 0:
             self.provider_combo.setCurrentIndex(index)
-        layout.addWidget(self.provider_combo)
+        provider_layout.addWidget(self.provider_combo)
+        provider_layout.addWidget(self.manage_keys_btn)
+        layout.addWidget(provider_row)
         self.provider_combo.currentIndexChanged.connect(
             lambda: self.load_models(prompt_for_key=True)
         )
+        self.manage_keys_btn.clicked.connect(self.manage_api_keys)
 
         layout.addWidget(QLabel("Model:"))
         model_row = QWidget()
@@ -464,3 +472,7 @@ class SettingsDialog(QDialog):
         )
         if directory:
             self.writable_root_edit.setText(directory)
+
+    def manage_api_keys(self) -> None:
+        """Open the API key manager dialog."""
+        ApiKeysDialog(self).exec()


### PR DESCRIPTION
## Summary
- let users manage API key storage from the settings dialog
- export new `ApiKeysDialog`
- document the manage API keys workflow

## Testing
- `python -m compileall gui_pyside6/ui gui_pyside6/utils`

------
https://chatgpt.com/codex/tasks/task_e_684c4582a0c483299171e7b1e37f8b04