### PR TITLE
Handle errors separately in history panel

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -530,11 +530,13 @@ class MainWindow(QMainWindow):
         cursor = self.output_view.textCursor()
         cursor.movePosition(QTextCursor.End)
         fmt = QTextCharFormat()
-        if text.startswith("Error:"):
+        is_error = text.startswith("Error:")
+        if is_error:
             fmt.setForeground(QColor("red"))
         cursor.insertText(text + "\n", fmt)
         self.output_view.setTextCursor(cursor)
-        self.history_view.appendPlainText(text)
+        if not is_error:
+            self.history_view.appendPlainText(text)
 
     def handle_log_line(self, level: str, text: str) -> None:
         if level == "error":


### PR DESCRIPTION
## Summary
- show error lines in red but don't copy them to history pane

## Testing
- `ruff check gui_pyside6/ui/main_window.py`
- `black --check gui_pyside6/ui/main_window.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c46984fdc832991d37757394e51d8