### PR TITLE
Handle free credit timeout gracefully

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -164,6 +164,10 @@ class CodexCommandWorker(QThread):
             for line in self.run_fn():
                 self.line_received.emit(line)
                 self.log_line.emit("info", line)
+        except codex_adapter.CodexTimeout as exc:
+            msg = str(exc)
+            self.line_received.emit(f"Error: {msg}")
+            self.log_line.emit("error", msg)
         except codex_adapter.CodexError as exc:
             for err_line in exc.stderr.strip().splitlines():
                 self.line_received.emit(f"Error: {err_line}")


### PR DESCRIPTION
## Summary
- add `CodexTimeout` exception
- support timeouts for CLI helper commands
- show timeout errors in the debug console

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat 9 files)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c476de40083299c97bc0887baa460