### PR TITLE
Implement provider configuration prompt

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -38,6 +38,9 @@ self.full_context_check = QCheckBox("Full Context")
   approval mode with auto-edit/full-auto toggles, reasoning effort and flex mode.
   The available providers are loaded from `resources/providers.json` and any
   modifications through **Manage Providers** are saved to `config/providers.json`.
+  When you select a provider that doesn't yet have an API key or base URL
+  configured, the GUI will prompt for those values so you can quickly switch
+  between multiple providers.
 
 ## Prerequisites
 
@@ -104,6 +107,7 @@ to force a fresh setup or edit the `VENV_DIR` variable near the top of
 4. If you choose the **OpenAI** provider, the GUI prompts for an API key the first time you run a session or refresh models when `OPENAI_API_KEY` is not set. The dialog includes a **Remember key** checkbox which saves the key in `config/api_keys.json` so you don't need to enter it again.
 5. The prompt also offers a **Get API Key** link that opens the OpenAI account page so you can quickly generate a new key.
 6. Open **File -> Settings** and click **Manage API Keys** to update or delete saved entries.
+7. Click **Manage Providers** in the Settings dialog to add custom providers. When you select a provider that doesn't have an API key or base URL configured, the GUI will prompt for them automatically.
 
 To set the key manually for the OpenAI provider:
 

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -177,6 +177,16 @@ When a Codex session is launched these selected files are passed to the CLI via
 
 ---
 
+## Multi-Provider Management
+
+Open **File -> Settings** and click **Manage Providers** to add or edit API
+endpoints. The provider drop-down lists all entries from
+`config/providers.json`. Selecting a provider without a stored API key or base
+URL will prompt for those values so you can easily switch between different
+Codex-compatible services.
+
+---
+
 ## Login & Free Credits
 
 The **Help** menu provides two account actions (relevant when using the OpenAI provider):

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -47,7 +47,7 @@ from ..plugins.loader import load_plugins
 from ..utils.highlighter import PythonHighlighter
 from ..utils.file_scanner import find_source_files
 from ..utils.project_paths import get_common_paths
-from ..utils.api_key import ensure_api_key
+from ..utils.api_key import ensure_api_key, ensure_base_url
 from pathlib import Path
 
 
@@ -474,6 +474,10 @@ class MainWindow(QMainWindow):
         provider = self.settings.get("provider", "openai")
         if provider not in {"local", "custom"}:
             if not ensure_api_key(provider, self):
+                return
+            providers = self.settings.get("providers", {})
+            info = providers.get(provider, {})
+            if not ensure_base_url(provider, info.get("baseURL"), self):
                 return
         prompt_text = (
             prompt if prompt is not None else self.prompt_edit.toPlainText().strip()

--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -28,7 +28,7 @@ from urllib import request
 from ..backend.settings_manager import save_settings
 from ..backend.model_manager import get_available_models
 from ..backend import codex_adapter
-from ..utils.api_key import ensure_api_key
+from ..utils.api_key import ensure_api_key, ensure_base_url
 from .api_keys_dialog import ApiKeysDialog
 from .. import logger
 
@@ -241,6 +241,9 @@ class SettingsDialog(QDialog):
                 else:
                     self.model_combo.clear()
                     return
+            if not ensure_base_url(provider, info.get("baseURL"), self):
+                self.model_combo.clear()
+                return
         if provider not in {"local", "custom"}:
             try:
                 models = get_available_models(provider)


### PR DESCRIPTION
## Summary
- support prompting for provider API key and base URL
- ensure provider dropdown works with stored providers
- document how to manage multiple providers and how prompts appear

## Testing
- `ruff check gui_pyside6`


------
https://chatgpt.com/codex/tasks/task_e_684c674bd9348329ab426d73dda3cace