### PR TITLE
Fix command logging in PySide6 GUI

### DIFF
--- a/gui_pyside6/backend/codex_adapter.py
+++ b/gui_pyside6/backend/codex_adapter.py
@@ -226,7 +226,7 @@ def build_command(
             if path_str:
                 cmd.extend(["--file", path_str])
 
-    cmd.append(prompt)
+    cmd.append(str(prompt))
     return cmd
 
 

--- a/gui_pyside6/tests/test_cli.py
+++ b/gui_pyside6/tests/test_cli.py
@@ -1,0 +1,50 @@
+import os
+import pytest
+try:
+    from PySide6.QtWidgets import QApplication
+except Exception as exc:  # pylint: disable=broad-except
+    pytest.skip(f"PySide6 not available: {exc}", allow_module_level=True)
+
+from gui_pyside6.backend import codex_adapter
+from gui_pyside6.backend.agent_manager import AgentManager
+from gui_pyside6.ui import main_window as main_window_module
+
+
+def test_build_command_returns_list_of_str():
+    agent = {"temperature": 0.3, "model": "gpt"}
+    settings = {"cli_path": "codex"}
+    cmd = codex_adapter.build_command("hello", agent, settings)
+    assert isinstance(cmd, list)
+    assert all(isinstance(part, str) for part in cmd)
+
+
+def test_start_codex_handles_command(monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+
+    # prevent actual CLI checks and execution
+    monkeypatch.setattr(codex_adapter, "ensure_cli_available", lambda *a, **k: None)
+    monkeypatch.setattr(codex_adapter, "start_session", lambda *a, **k: iter([]))
+
+    class DummySignal:
+        def connect(self, fn):
+            pass
+
+    class DummyWorker:
+        def __init__(self, *a, **k):
+            self.line_received = DummySignal()
+            self.log_line = DummySignal()
+            self.finished = DummySignal()
+        def start(self):
+            pass
+        def isRunning(self):
+            return False
+
+    monkeypatch.setattr(main_window_module, "CodexWorker", DummyWorker)
+
+    agent_manager = AgentManager()
+    settings = {}
+    window = main_window_module.MainWindow(agent_manager, settings)
+    window.prompt_edit.setPlainText("hi")
+    window.start_codex()
+

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -510,9 +510,10 @@ class MainWindow(QMainWindow):
             files=file_paths if file_paths else None,
             cwd=cwd_arg,
         )
+        cmd_str = " ".join(str(part) for part in cmd)
         if self.settings.get("verbose"):
-            self.append_output("$ " + " ".join(cmd))
-        logger.info("$ " + " ".join(cmd))
+            self.append_output("$ " + cmd_str)
+        logger.info("$ " + cmd_str)
         self.worker = CodexWorker(
             prompt_text,
             agent,


### PR DESCRIPTION
## Summary
- log start_codex commands by joining parts as strings
- ensure build_command appends prompt as a string
- add basic tests for command building and start_codex

## Testing
- `pytest -q gui_pyside6/tests` *(fails: PySide6 not available)*

------
https://chatgpt.com/codex/tasks/task_e_684c703a9a9c8329b3125b0922597c87