### PR TITLE
Add npx fallback for Codex CLI

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -141,6 +141,9 @@ binary is usually located under `~/.local/share/pnpm` on Linux/macOS or
 `C:\Users\NAME\AppData\Local\pnpm` on Windows. Pointing the setting to this
 file ensures the GUI can launch the CLI correctly.
 
+If no executable is found, the GUI will try `npx codex --help`. When successful
+it automatically uses `npx codex --no-update-notifier` as the command.
+
 ---
 
 ## Project Structure

--- a/gui_pyside6/tests/test_cli.py
+++ b/gui_pyside6/tests/test_cli.py
@@ -18,6 +18,14 @@ def test_build_command_returns_list_of_str():
     assert all(isinstance(part, str) for part in cmd)
 
 
+def test_build_command_with_npx_command():
+    agent = {"temperature": 0.3}
+    settings = {"cli_path": "npx codex --no-update-notifier"}
+    cmd = codex_adapter.build_command("hi", agent, settings)
+    assert cmd[:3] == ["npx", "codex", "--no-update-notifier"]
+    assert cmd[-1] == "hi"
+
+
 def test_start_codex_handles_command(monkeypatch):
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     app = QApplication.instance() or QApplication([])


### PR DESCRIPTION
## Summary
- add `npx` fallback detection in `ensure_cli_available`
- allow `cli_path` to be a full command string
- update login and redeem helpers for split command
- test command building with an `npx` path
- document `npx` fallback in troubleshooting docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c77cbd0848329b134f775dd5b83e6