### PR TITLE
Update CLI command label and tests

### DIFF
--- a/gui_pyside6/tests/test_settings_dialog.py
+++ b/gui_pyside6/tests/test_settings_dialog.py
@@ -30,3 +30,16 @@ def test_load_models_parses_json(monkeypatch):
     dialog = SettingsDialog(settings)
     models = [dialog.model_combo.itemText(i) for i in range(dialog.model_combo.count())]
     assert "test-model" in models
+
+
+def test_cli_command_with_spaces_preserved(monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    settings = {}
+
+    dialog = SettingsDialog(settings)
+    command = "npx codex --no-update-notifier"
+    dialog.cli_edit.setText(command)
+    dialog.accept()
+
+    assert settings["cli_path"] == command

--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -157,12 +157,15 @@ class SettingsDialog(QDialog):
         self.full_context_check.setChecked(bool(settings.get("full_context", False)))
         layout.addWidget(self.full_context_check)
 
-        layout.addWidget(QLabel("Codex CLI Path:"))
+        layout.addWidget(QLabel("Codex CLI Command:"))
         cli_row = QWidget()
         cli_layout = QHBoxLayout(cli_row)
         cli_layout.setContentsMargins(0, 0, 0, 0)
         self.cli_edit = QLineEdit()
         self.cli_edit.setText(settings.get("cli_path", ""))
+        self.cli_edit.setToolTip(
+            "Full command allowed, e.g. 'npx codex --no-update-notifier'"
+        )
         browse_btn = QPushButton("Browse")
         browse_btn.clicked.connect(self.browse_cli)
         check_btn = QPushButton("Check")
@@ -448,7 +451,7 @@ class SettingsDialog(QDialog):
             self.cli_edit.setText(filename)
 
     def check_cli(self) -> None:
-        """Verify the Codex CLI path and log search details."""
+        """Verify the Codex CLI command and log search details."""
 
         def log_fn(text: str, level: str = "info") -> None:
             if level == "error":


### PR DESCRIPTION
## Summary
- clarify CLI label is a command
- tooltip explains full command usage
- check_cli verifies full command via codex_adapter
- add test for saving CLI command with spaces

## Testing
- `pytest gui_pyside6/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_684c78b3b1808329a4f66ee9519e528e