### PR TITLE
Add helper for codex.cmd wrapper

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -144,6 +144,10 @@ file ensures the GUI can launch the CLI correctly.
 If no executable is found, the GUI will try `npx codex --help`. When successful
 it automatically uses `npx codex --no-update-notifier` as the command.
 
+On Windows you can also create a simple `codex.cmd` wrapper via **File -> Settings**.
+It calls `npx codex --no-update-notifier` so the CLI is accessible from any
+terminal. Add the chosen directory to your `PATH` if needed.
+
 ---
 
 ## Project Structure

--- a/gui_pyside6/tests/test_codex_cmd.py
+++ b/gui_pyside6/tests/test_codex_cmd.py
@@ -1,0 +1,17 @@
+import os
+
+from gui_pyside6.utils.codex_cmd import create_codex_cmd, path_in_env
+
+
+def test_create_codex_cmd_writes_file(tmp_path):
+    cmd_path = create_codex_cmd(tmp_path)
+    assert cmd_path.exists()
+    assert "npx codex --no-update-notifier %*" in cmd_path.read_text()
+
+
+def test_path_in_env(tmp_path, monkeypatch):
+    env_path = str(tmp_path)
+    monkeypatch.setenv("PATH", os.pathsep.join([env_path]))
+    assert path_in_env(tmp_path)
+    monkeypatch.setenv("PATH", "")
+    assert not path_in_env(tmp_path)

--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -31,6 +31,7 @@ from ..backend.settings_manager import save_settings
 from ..backend.model_manager import get_available_models
 from ..backend import codex_adapter
 from ..utils.api_key import ensure_api_key, ensure_base_url
+from ..utils import create_codex_cmd, path_in_env
 from .api_keys_dialog import ApiKeysDialog
 from .. import logger
 
@@ -174,6 +175,10 @@ class SettingsDialog(QDialog):
         cli_layout.addWidget(browse_btn)
         cli_layout.addWidget(check_btn)
         layout.addWidget(cli_row)
+        if os.name == "nt":
+            create_cmd_btn = QPushButton("Create codex.cmd...")
+            create_cmd_btn.clicked.connect(self.create_codex_cmd_file)
+            layout.addWidget(create_cmd_btn)
 
         self.verbose_check = QCheckBox("Verbose")
         self.verbose_check.setChecked(bool(settings.get("verbose", False)))
@@ -492,6 +497,23 @@ class SettingsDialog(QDialog):
         )
         if directory:
             self.writable_root_edit.setText(directory)
+
+    def create_codex_cmd_file(self) -> None:
+        """Create a ``codex.cmd`` wrapper in a chosen directory (Windows)."""
+        directory = QFileDialog.getExistingDirectory(
+            self,
+            "Select Directory for codex.cmd",
+            str(Path.home()),
+        )
+        if not directory:
+            return
+        path = create_codex_cmd(directory)
+        message = f"Created {path}"
+        if not path_in_env(directory):
+            message += (
+                "\n\nAdd this directory to your PATH to invoke 'codex' from any terminal."
+            )
+        QMessageBox.information(self, "codex.cmd Created", message)
 
     def manage_api_keys(self) -> None:
         """Open the API key manager dialog."""

--- a/gui_pyside6/utils/__init__.py
+++ b/gui_pyside6/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers used across the PySide6 GUI."""
+
+from .codex_cmd import create_codex_cmd, path_in_env
+
+__all__ = ["create_codex_cmd", "path_in_env"]

--- a/gui_pyside6/utils/codex_cmd.py
+++ b/gui_pyside6/utils/codex_cmd.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+__all__ = ["create_codex_cmd", "path_in_env"]
+
+
+def create_codex_cmd(directory: str | Path) -> Path:
+    """Create ``codex.cmd`` in *directory* invoking ``npx codex``.
+
+    Returns the path to the created file.
+    """
+    path = Path(directory).expanduser().resolve()
+    path.mkdir(parents=True, exist_ok=True)
+    cmd_file = path / "codex.cmd"
+    with cmd_file.open("w", encoding="utf-8") as fh:
+        fh.write("@echo off\n")
+        fh.write("npx codex --no-update-notifier %*\n")
+    return cmd_file
+
+
+def path_in_env(directory: str | Path) -> bool:
+    """Return ``True`` if *directory* is in the ``PATH`` environment variable."""
+    directory = str(Path(directory).resolve())
+    parts = os.environ.get("PATH", "").split(os.pathsep)
+    return any(Path(p).resolve() == Path(directory) for p in parts if p)


### PR DESCRIPTION
## Summary
- add `create_codex_cmd()` helper to generate a `codex.cmd` wrapper
- expose a `Create codex.cmd...` button in Settings on Windows
- notify user to add chosen dir to PATH when necessary
- document convenience wrapper in README
- test codex.cmd helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7982d0088329a7eb82d2cada4629