### PR TITLE
Fix syntax formatter logging

### DIFF
--- a/gui_pyside6/plugins/syntax_formatter.py
+++ b/gui_pyside6/plugins/syntax_formatter.py
@@ -53,10 +53,10 @@ def register(window) -> None:
         try:
             formatted, error = _format_text(original)
         except Exception as exc:  # pylint: disable=broad-except
-            window.output_view.append(f"Format error: {exc}")
+            window.output_view.appendPlainText(f"Format error: {exc}")
             return
         if error:
-            window.output_view.append(f"Format error: {error}")
+            window.output_view.appendPlainText(f"Format error: {error}")
             return
         if formatted is not None:
             window.prompt_edit.setPlainText(formatted)


### PR DESCRIPTION
## Summary
- update syntax formatter to use `appendPlainText` for error messages

## Testing
- `pip install PySide6 psutil python-dotenv rich aiofiles httpx openai`
- `pytest -q gui_pyside6/tests`

------
https://chatgpt.com/codex/tasks/task_e_684c7e250f048329b9c1295686d233bc