### PR TITLE
Implement Ollama ps JSON detection

### DIFF
--- a/gui_pyside6/tests/test_settings_dialog.py
+++ b/gui_pyside6/tests/test_settings_dialog.py
@@ -67,3 +67,36 @@ def test_cli_command_with_spaces_preserved(monkeypatch):
     dialog.accept()
 
     assert settings["cli_path"] == command
+
+
+def test_ollama_ps_json_flag_cached(monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    settings = {"provider": "local", "providers": {"local": {"name": "Local"}}}
+
+    monkeypatch.setattr(shutil, "which", lambda x: "/usr/bin/ollama")
+    calls = []
+
+    def fake_run(cmd, capture_output=True, text=True, timeout=5, check=False):
+        calls.append(cmd)
+        if cmd[:3] == ["ollama", "list", "--json"] or cmd[:3] == ["ollama", "ls", "--json"]:
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="unknown flag: --json")
+        if cmd[:2] in (["ollama", "list"], ["ollama", "ls"]):
+            stdout = "NAME ID SIZE\nmodel1 id1 1 GB"
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+        if cmd[:2] == ["ollama", "ps"]:
+            if cmd[-1] == "--json":
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="unknown flag: --json")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    import gui_pyside6.ui.settings_dialog as sd
+    sd._OLLAMA_PS_JSON = None
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    dialog = SettingsDialog(settings)
+    dialog.load_models()
+
+    ps_cmds = [c for c in calls if c[:2] == ["ollama", "ps"]]
+    assert ps_cmds[0] == ["ollama", "ps", "--json"]
+    assert ps_cmds[1] == ["ollama", "ps"]


### PR DESCRIPTION
## Summary
- cache detection for `ollama ps --json`
- fall back to plain text when unsupported
- test `ollama ps` flag detection logic

## Testing
- `ruff check gui_pyside6/ui/settings_dialog.py gui_pyside6/tests/test_settings_dialog.py`
- `pytest gui_pyside6/tests/test_settings_dialog.py -q` *(fails: 1 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_684c822fbd0083298531da0777c26ac7