### PR TITLE
Add provider parameter to ApiKeyDialog

### DIFF
--- a/gui_pyside6/ui/api_key_dialog.py
+++ b/gui_pyside6/ui/api_key_dialog.py
@@ -13,14 +13,15 @@ from PySide6.QtWidgets import (
 
 
 class ApiKeyDialog(QDialog):
-    """Dialog to request an OpenAI API key from the user."""
+    """Dialog to request an API key for a provider."""
 
-    def __init__(self, parent: QDialog | None = None) -> None:
+    def __init__(self, provider: str, parent: QDialog | None = None) -> None:
         super().__init__(parent)
-        self.setWindowTitle("Enter OpenAI API Key")
+        provider_title = provider.capitalize()
+        self.setWindowTitle(f"Enter {provider_title} API Key")
 
         layout = QVBoxLayout(self)
-        layout.addWidget(QLabel("Please enter your OpenAI API key:"))
+        layout.addWidget(QLabel(f"Please enter your {provider_title} API key:"))
 
         self.key_edit = QLineEdit()
         self.key_edit.setEchoMode(QLineEdit.Password)

--- a/gui_pyside6/ui/api_keys_dialog.py
+++ b/gui_pyside6/ui/api_keys_dialog.py
@@ -62,8 +62,7 @@ class ApiKeysDialog(QDialog):
         if not provider:
             QMessageBox.information(self, "No Selection", "Please select a provider.")
             return
-        dialog = ApiKeyDialog(self)
-        dialog.setWindowTitle(f"{provider.capitalize()} API Key")
+        dialog = ApiKeyDialog(provider, self)
         dialog.key_edit.setText(self.keys.get(provider, ""))
         dialog.remember_check.setChecked(True)
         if dialog.exec() == QDialog.Accepted:

--- a/gui_pyside6/utils/api_key.py
+++ b/gui_pyside6/utils/api_key.py
@@ -63,7 +63,7 @@ def ensure_api_key(provider: str, parent: QWidget | None = None) -> bool:
     if api_key:
         return True
 
-    dialog = ApiKeyDialog(parent)
+    dialog = ApiKeyDialog(provider, parent)
     if dialog.exec() == QDialog.Accepted:
         key = dialog.api_key()
         if key:


### PR DESCRIPTION
## Summary
- customize ApiKeyDialog with provider name
- pass provider when prompting for keys from api_key utils
- pass provider when updating stored keys

## Testing
- `pytest -q gui_pyside6/tests`

------
https://chatgpt.com/codex/tasks/task_e_684c83ee4a50832997b9127942c61cb0