### PR TITLE
Rename Run button to Send

### DIFF
--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -129,7 +129,7 @@ The main window uses a horizontal splitter:
 - **Center panel** - prompt editor with streaming output beneath.
 - **Right panel** - scrollable history of the session.
 
-Run and Stop actions appear in both a toolbar at the top and a button bar below
+Send and Stop actions appear in both a toolbar at the top and a button bar below
 the editor. The bottom status bar shows the active agent and session updates.
 If the CLI fails, its stderr messages are printed in the output panel.
 Detailed stdout and stderr are also routed to the **Debug Console**.

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -211,7 +211,7 @@ class MainWindow(QMainWindow):
         view_menu = menu_bar.addMenu("View")
         help_menu = menu_bar.addMenu("Help")
 
-        self.run_action = QAction("Run", self)
+        self.run_action = QAction("Send", self)
         self.run_action.triggered.connect(self.start_codex)
         file_menu.addAction(self.run_action)
 
@@ -417,7 +417,7 @@ class MainWindow(QMainWindow):
         center_layout.addLayout(button_bar)
         self.button_bar = button_bar
 
-        self.run_btn = QPushButton("Run")
+        self.run_btn = QPushButton("Send")
         self.run_btn.clicked.connect(self.start_codex)
         button_bar.addWidget(self.run_btn)
 


### PR DESCRIPTION
## Summary
- rename "Run" action and button to "Send" in main window
- update documentation to reflect Send action

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c850e9b9c832990c88823f5acf0f9