### PR TITLE
Fix provider refresh logic and add regression test

### DIFF
--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -578,12 +578,20 @@ class SettingsDialog(QDialog):
 
     def refresh_providers(self) -> None:
         """Populate the provider combo from settings."""
+        prev = self.provider_combo.currentData()
+
+        self.provider_combo.blockSignals(True)
         self.provider_combo.clear()
         providers = self.settings.get("providers", {})
         for key, info in sorted(providers.items()):
             name = info.get("name", key)
             self.provider_combo.addItem(name, key)
-        current = self.settings.get("provider", "openai")
-        index = self.provider_combo.findData(current)
+
+        selected = prev if prev is not None else self.settings.get("provider", "openai")
+        index = self.provider_combo.findData(selected)
         if index >= 0:
             self.provider_combo.setCurrentIndex(index)
+        self.provider_combo.blockSignals(False)
+
+        if prev != self.provider_combo.currentData():
+            self.load_models(prompt_for_key=True)


### PR DESCRIPTION
## Summary
- preserve selected provider when refreshing settings
- call `load_models()` if the provider changed during refresh
- test that selecting Ollama keeps the selection and loads models

## Testing
- `pytest -q gui_pyside6/tests`

------
https://chatgpt.com/codex/tasks/task_e_684c8a3e7ae88329a3c72baf8243924d