### PR TITLE
Improve TTS plugin to read latest output

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -224,7 +224,7 @@ Example plugins included:
 
 - **Syntax Formatter** - adds a *Format* button that runs the Black formatter on the prompt editor.
 - **Agent Logger** - records prompts and responses to `agent_log.txt` when enabled.
-- **TTS Player** - speaks the current prompt using gTTS (disabled by default).
+- **TTS Player** - reads the last response using gTTS (disabled by default).
 
 Some plugins rely on optional TTS backends. These dependencies are installed on demand via `ensure_backend_installed()` which detects your active virtual environment or falls back to `~/.hybrid_tts/venv`.
 

--- a/gui_pyside6/plugins/tts_player.py
+++ b/gui_pyside6/plugins/tts_player.py
@@ -1,4 +1,8 @@
-"""Plugin that speaks text using gTTS."""
+"""Plugin that speaks text using gTTS.
+
+The *Speak* button now reads the most recent line from ``window.output_view``.
+If the output is empty, it falls back to the current prompt text.
+"""
 
 from __future__ import annotations
 
@@ -38,7 +42,10 @@ def register(window) -> None:
     player.playbackStateChanged.connect(on_state_changed)
 
     def on_click() -> None:
-        text = window.prompt_edit.toPlainText().strip()
+        lines = window.output_view.toPlainText().strip().splitlines()
+        text = lines[-1] if lines else ""
+        if not text:
+            text = window.prompt_edit.toPlainText().strip()
         if not text:
             return
 


### PR DESCRIPTION
## Summary
- update TTS plugin to speak most recent output line
- fall back to reading the prompt if no output exists
- document TTS button behaviour in plugin and README

## Testing
- `pytest -q gui_pyside6/tests`

------
https://chatgpt.com/codex/tasks/task_e_684c8bb36b5c8329aad116881b48a183