### PR TITLE
Fix provider refresh initialization

### DIFF
--- a/gui_pyside6/tests/test_settings_dialog.py
+++ b/gui_pyside6/tests/test_settings_dialog.py
@@ -142,3 +142,15 @@ def test_provider_selection_persists_and_loads_models(monkeypatch):
 
     assert dialog.provider_combo.currentData() == "ollama"
     assert dialog.model_combo.findText("ollama-model") >= 0
+
+def test_load_models_called_after_model_combo_created(monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    settings = {"provider": "openai", "providers": {"openai": {"name": "OpenAI"}}}
+
+    def fake_load_models(self, prompt_for_key=False):
+        assert hasattr(self, "model_combo")
+
+    monkeypatch.setattr(SettingsDialog, "load_models", fake_load_models)
+
+    SettingsDialog(settings)

--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -110,15 +110,7 @@ class SettingsDialog(QDialog):
         provider_layout.addWidget(self.provider_combo)
         provider_layout.addWidget(self.manage_keys_btn)
         provider_layout.addWidget(self.manage_providers_btn)
-        self.refresh_providers()
-        layout.addWidget(provider_row)
-        self.provider_combo.currentIndexChanged.connect(
-            lambda: self.load_models(prompt_for_key=True)
-        )
-        self.manage_keys_btn.clicked.connect(self.manage_api_keys)
-        self.manage_providers_btn.clicked.connect(self.manage_providers)
 
-        layout.addWidget(QLabel("Model:"))
         model_row = QWidget()
         model_layout = QHBoxLayout(model_row)
         model_layout.setContentsMargins(0, 0, 0, 0)
@@ -127,6 +119,17 @@ class SettingsDialog(QDialog):
         refresh_btn.clicked.connect(lambda: self.load_models(prompt_for_key=True))
         model_layout.addWidget(self.model_combo)
         model_layout.addWidget(refresh_btn)
+
+        self.refresh_providers()
+
+        layout.addWidget(provider_row)
+        self.provider_combo.currentIndexChanged.connect(
+            lambda: self.load_models(prompt_for_key=True)
+        )
+        self.manage_keys_btn.clicked.connect(self.manage_api_keys)
+        self.manage_providers_btn.clicked.connect(self.manage_providers)
+
+        layout.addWidget(QLabel("Model:"))
         layout.addWidget(model_row)
         self.load_models()
 


### PR DESCRIPTION
## Summary
- ensure SettingsDialog creates `model_combo` before refreshing providers
- verify refresh order via regression test

## Testing
- `pytest gui_pyside6/tests/test_settings_dialog.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684c90dd5c54832994e6f8ec94eb2f7d