### PR TITLE
Fix ApiKeyDialog button creation

### DIFF
--- a/gui_pyside6/tests/test_settings_dialog.py
+++ b/gui_pyside6/tests/test_settings_dialog.py
@@ -154,3 +154,17 @@ def test_load_models_called_after_model_combo_created(monkeypatch):
     monkeypatch.setattr(SettingsDialog, "load_models", fake_load_models)
 
     SettingsDialog(settings)
+
+
+def test_api_key_dialog_get_key_button_visibility():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+
+    from gui_pyside6.ui.api_key_dialog import ApiKeyDialog
+
+    openai_dialog = ApiKeyDialog("openai")
+    assert hasattr(openai_dialog, "get_key_button")
+
+    ollama_dialog = ApiKeyDialog("ollama")
+    assert not hasattr(ollama_dialog, "get_key_button")
+

--- a/gui_pyside6/ui/api_key_dialog.py
+++ b/gui_pyside6/ui/api_key_dialog.py
@@ -30,13 +30,14 @@ class ApiKeyDialog(QDialog):
         self.remember_check = QCheckBox("Remember key")
         layout.addWidget(self.remember_check)
 
-        self.get_key_button = QPushButton("Get API Key")
-        self.get_key_button.clicked.connect(
-            lambda: QDesktopServices.openUrl(
-                QUrl("https://platform.openai.com/account/api-keys")
+        if provider.lower() == "openai":
+            self.get_key_button = QPushButton("Get API Key")
+            self.get_key_button.clicked.connect(
+                lambda: QDesktopServices.openUrl(
+                    QUrl("https://platform.openai.com/account/api-keys")
+                )
             )
-        )
-        layout.addWidget(self.get_key_button)
+            layout.addWidget(self.get_key_button)
 
         button_layout = QVBoxLayout()
         self.ok_button = QPushButton("OK")


### PR DESCRIPTION
## Summary
- create `get_key_button` only when provider is `openai`
- test `ApiKeyDialog` button visibility for different providers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9e698ce88329ad028e4ccc9e366a