### PR TITLE
Update docs on config file persistence

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -42,6 +42,12 @@ self.full_context_check = QCheckBox("Full Context")
   configured, the GUI will prompt for those values so you can quickly switch
   between multiple providers.
 
+Runtime settings from the dialog (quiet mode, full context, model choice, etc.)
+are persisted in `config/settings.json`. Provider overrides and any custom
+entries you add are written to `config/providers.json`. These files are created
+after the first launch and can be manually edited to tweak defaults outside of
+the GUI.
+
 ## Prerequisites
 
 - Python 3.9 or newer

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -185,6 +185,11 @@ endpoints. The provider drop-down lists all entries from
 URL will prompt for those values so you can easily switch between different
 Codex-compatible services.
 
+Runtime preferences from the settings dialog are written to `config/settings.json`.
+Provider overrides and custom endpoints are stored in `config/providers.json`.
+Both files are created after the first launch and can be edited manually to tweak
+defaults outside of the GUI.
+
 ---
 
 ## Login & Free Credits


### PR DESCRIPTION
## Summary
- describe location and persistence of settings and provider overrides in `gui_pyside6/README.md`
- document same details in `gui_pyside6/docs/index.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca0833ffc8329b75e86c42e8f16a9