### PR TITLE
Add theme selection to Hybrid GUI

### DIFF
--- a/gui_pyside6/backend/settings_manager.py
+++ b/gui_pyside6/backend/settings_manager.py
@@ -22,6 +22,8 @@ DEFAULT_SETTINGS = {
     "flex_mode": False,
     "quiet": False,
     "full_context": False,
+    # UI theme: "System", "Light", or "Dark"
+    "theme": "System",
     "selected_agent": "Python Expert",
     # Optional path to the Codex CLI executable. If empty, the adapter will
     # search the system PATH or use the bundled Node.js script.

--- a/gui_pyside6/main.py
+++ b/gui_pyside6/main.py
@@ -1,17 +1,44 @@
 from __future__ import annotations
 
 import sys
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QPalette
+from PySide6.QtGui import QColor
+from PySide6.QtCore import Qt
 
 from .backend.settings_manager import load_settings
 from .backend.agent_manager import AgentManager
 from .ui import MainWindow
+
+
+def apply_theme(app: QApplication, theme: str) -> None:
+    """Apply light or dark theme to the application."""
+    if theme == "Dark":
+        app.setStyle("Fusion")
+        palette = QPalette()
+        palette.setColor(QPalette.Window, QColor(53, 53, 53))
+        palette.setColor(QPalette.WindowText, Qt.white)
+        palette.setColor(QPalette.Base, QColor(25, 25, 25))
+        palette.setColor(QPalette.AlternateBase, QColor(53, 53, 53))
+        palette.setColor(QPalette.ToolTipBase, Qt.white)
+        palette.setColor(QPalette.ToolTipText, Qt.white)
+        palette.setColor(QPalette.Text, Qt.white)
+        palette.setColor(QPalette.Button, QColor(53, 53, 53))
+        palette.setColor(QPalette.ButtonText, Qt.white)
+        palette.setColor(QPalette.BrightText, Qt.red)
+        palette.setColor(QPalette.Link, QColor(42, 130, 218))
+        palette.setColor(QPalette.Highlight, QColor(42, 130, 218))
+        palette.setColor(QPalette.HighlightedText, Qt.black)
+        app.setPalette(palette)
+    elif theme == "Light":
+        app.setStyle("Fusion")
+        app.setPalette(app.style().standardPalette())
 
 def main() -> None:
     """Entry point for the Hybrid PySide6 GUI."""
     app = QApplication(sys.argv)
 
     settings = load_settings()
+    apply_theme(app, settings.get("theme", "System"))
     agent_manager = AgentManager()
     agent_manager.set_active_agent(settings.get("selected_agent", ""))
 

--- a/gui_pyside6/tests/test_settings_dialog.py
+++ b/gui_pyside6/tests/test_settings_dialog.py
@@ -168,3 +168,16 @@ def test_api_key_dialog_get_key_button_visibility():
     ollama_dialog = ApiKeyDialog("ollama")
     assert not hasattr(ollama_dialog, "get_key_button")
 
+
+def test_theme_selection_saved():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+
+    settings = {}
+    dialog = SettingsDialog(settings)
+    index = dialog.theme_combo.findText("Dark")
+    dialog.theme_combo.setCurrentIndex(index)
+    dialog.accept()
+
+    assert settings["theme"] == "Dark"
+

--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -154,6 +154,12 @@ class SettingsDialog(QDialog):
         self.reason_combo.setCurrentText(settings.get("reasoning", "high"))
         layout.addWidget(self.reason_combo)
 
+        layout.addWidget(QLabel("Theme:"))
+        self.theme_combo = QComboBox()
+        self.theme_combo.addItems(["System", "Light", "Dark"])
+        self.theme_combo.setCurrentText(settings.get("theme", "System"))
+        layout.addWidget(self.theme_combo)
+
         self.flex_check = QCheckBox("Flex Mode")
         self.flex_check.setChecked(bool(settings.get("flex_mode", False)))
         layout.addWidget(self.flex_check)
@@ -478,6 +484,7 @@ class SettingsDialog(QDialog):
         self.settings["auto_edit"] = approval == "auto-edit"
         self.settings["full_auto"] = approval == "full-auto"
         self.settings["reasoning"] = self.reason_combo.currentText()
+        self.settings["theme"] = self.theme_combo.currentText()
         self.settings["flex_mode"] = self.flex_check.isChecked()
         self.settings["quiet"] = self.quiet_check.isChecked()
         self.settings["full_context"] = self.full_context_check.isChecked()


### PR DESCRIPTION
## Summary
- add `theme` default to the settings manager
- expose a theme combo box in `SettingsDialog`
- save selected theme on dialog accept
- apply light or dark palettes on startup
- test theme value persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca7fc4d748329aa94cd6859a3d1a3