### PR TITLE
Add keyboard shortcuts for Codex start/stop

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -212,6 +212,11 @@ By default the GUI records INFO and ERROR messages to `logs/gui.log`. Set the
 environment variable `CODEX_GUI_LOGGING=0` before launching to disable this
 file logging while keeping the Debug Console active.
 
+### Keyboard Shortcuts
+
+- **Ctrl+Enter** – start a Codex session (same as clicking **Send**)
+- **Esc** – stop the running session
+
 ## Docs
 
 For agent presets, architecture decisions, and developer info, see:

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -469,6 +469,16 @@ class MainWindow(QMainWindow):
         self.stop_btn.clicked.connect(self.stop_codex)
         button_bar.addWidget(self.stop_btn)
 
+        QShortcut(
+            QKeySequence(Qt.CTRL | Qt.Key_Return), self
+        ).activated.connect(self.start_codex)
+        QShortcut(
+            QKeySequence(Qt.CTRL | Qt.Key_Enter), self
+        ).activated.connect(self.start_codex)
+        QShortcut(QKeySequence(Qt.Key_Escape), self).activated.connect(
+            self.stop_codex
+        )
+
         splitter.addWidget(center_widget)
 
         # ----------------------- Right Panel -----------------------


### PR DESCRIPTION
## Summary
- add Ctrl+Enter and Esc shortcuts to start/stop Codex
- document shortcuts in PySide6 README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684caa6a285c8329b5d91b5da138b74a