### PR TITLE
Add optional uv sandbox for CLI

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,4 +22,6 @@ At startup the PySide6 app scans the current working directory for common source
 
 Use **Add File** to include additional paths or **Remove** to exclude them. When a Codex session is launched these selected files are passed to the CLI via `--file` flags so Codex can read them as context.
 
+The GUI can also wrap the CLI with `uv run` by enabling **Use uv Sandbox** in the Settings dialog.
+
 See the [PySide6 docs](../gui_pyside6/docs/index.md) for full details.

--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -24,6 +24,7 @@ This project reimagines the Codex CLI as a desktop application, offering:
 - Runtime settings for temperature, model, provider, penalties and more passed as CLI flags
 - Remembers the last selected agent across restarts
 - Optional verbose mode prints the exact CLI command before execution
+- Use uv Sandbox to run the CLI via `uv run` for extra isolation
 - Quiet mode hides progress output while Full Context sends the entire conversation. Both map to the CLI flags `--quiet` and `--full-context`
 - Dockable **Debug Console** shows stdout/stderr from Codex and tool runs
 - Show or hide the left and right panels, or the Debug Console, from the **View** menu

--- a/gui_pyside6/backend/codex_adapter.py
+++ b/gui_pyside6/backend/codex_adapter.py
@@ -176,6 +176,8 @@ def build_command(
 
     cli_exe = settings.get("cli_path") or "codex"
     cmd: list[str] = shlex.split(str(cli_exe))
+    if settings.get("use_uv_sandbox"):
+        cmd = ["uv", "run", *cmd]
 
     def add_flag(flag: str, value: object | None) -> None:
         """Safely append a flag and value to the command list."""
@@ -396,6 +398,8 @@ def login(settings: dict | None = None) -> Iterable[str]:
     settings = settings or {}
     cli_exe = settings.get("cli_path") or "codex"
     cmd = shlex.split(str(cli_exe)) + ["--login"]
+    if settings.get("use_uv_sandbox"):
+        cmd = ["uv", "run", *cmd]
     yield from _run_simple_command(cmd)
 
 
@@ -418,4 +422,6 @@ def redeem_free_credits(
         timeout = float(settings.get("redeem_timeout", 30))
     cli_exe = settings.get("cli_path") or "codex"
     cmd = shlex.split(str(cli_exe)) + ["--free"]
+    if settings.get("use_uv_sandbox"):
+        cmd = ["uv", "run", *cmd]
     yield from _run_simple_command(cmd, timeout=timeout)

--- a/gui_pyside6/backend/settings_manager.py
+++ b/gui_pyside6/backend/settings_manager.py
@@ -30,6 +30,8 @@ DEFAULT_SETTINGS = {
     "cli_path": "",
     # Print the final CLI command in the output view when running a session.
     "verbose": False,
+    # Run CLI commands inside `uv run` for isolation
+    "use_uv_sandbox": False,
     "notify": False,
     "project_doc": "",
     "no_project_doc": False,

--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -103,6 +103,7 @@ mode, set the reasoning effort, and enable flex mode.
 Enable **Verbose Mode** in the settings dialog to print the final CLI command before each run.
 Quiet mode suppresses progress output and reduces logging noise. Full Context passes the entire chat history to the CLI using the `--full-context` flag.
 To enable these modes, tick **Quiet Mode** or **Full Context** in the Settings dialog.
+Enable **Use uv Sandbox** to run the CLI via `uv run` for extra isolation.
 ```python
 self.quiet_check = QCheckBox("Quiet Mode")
 self.full_context_check = QCheckBox("Full Context")
@@ -256,7 +257,7 @@ Open **Plugins -> Plugin Manager** to enable or disable optional plugins listed 
 - [x] Run CLI subprocess and parse output
 - [x] Add file-aware completions
 - [x] Build debug panel (logs, errors, console)
-- [ ] Execution in `uv` sandbox
+- [x] Execution in `uv` sandbox
 - [x] Plugin manager
 - [x] Drag-and-drop file attachments
 - [x] Quiet & full-context CLI flags

--- a/gui_pyside6/tests/test_cli.py
+++ b/gui_pyside6/tests/test_cli.py
@@ -26,6 +26,14 @@ def test_build_command_with_npx_command():
     assert cmd[-1] == "hi"
 
 
+def test_build_command_with_uv_sandbox():
+    agent = {"temperature": 0.3}
+    settings = {"cli_path": "codex", "use_uv_sandbox": True}
+    cmd = codex_adapter.build_command("hi", agent, settings)
+    assert cmd[:3] == ["uv", "run", "codex"]
+    assert cmd[-1] == "hi"
+
+
 def test_start_codex_handles_command(monkeypatch):
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     app = QApplication.instance() or QApplication([])

--- a/gui_pyside6/ui/settings_dialog.py
+++ b/gui_pyside6/ui/settings_dialog.py
@@ -198,6 +198,10 @@ class SettingsDialog(QDialog):
         self.verbose_check.setChecked(bool(settings.get("verbose", False)))
         layout.addWidget(self.verbose_check)
 
+        self.uv_sandbox_check = QCheckBox("Use uv Sandbox")
+        self.uv_sandbox_check.setChecked(bool(settings.get("use_uv_sandbox", False)))
+        layout.addWidget(self.uv_sandbox_check)
+
         self.notify_check = QCheckBox("Notify")
         self.notify_check.setChecked(bool(settings.get("notify", False)))
         layout.addWidget(self.notify_check)
@@ -490,6 +494,7 @@ class SettingsDialog(QDialog):
         self.settings["full_context"] = self.full_context_check.isChecked()
         self.settings["cli_path"] = self.cli_edit.text().strip()
         self.settings["verbose"] = self.verbose_check.isChecked()
+        self.settings["use_uv_sandbox"] = self.uv_sandbox_check.isChecked()
         self.settings["notify"] = self.notify_check.isChecked()
         self.settings["no_project_doc"] = self.no_project_doc_check.isChecked()
         self.settings["disable_response_storage"] = (


### PR DESCRIPTION
## Summary
- add `use_uv_sandbox` to default settings
- show "Use uv Sandbox" checkbox in Settings dialog
- run CLI commands through `uv run` when enabled
- document the sandbox option in docs and README
- test `build_command` with uv sandbox

## Testing
- `pytest -q gui_pyside6/tests`

------
https://chatgpt.com/codex/tasks/task_e_684cab576f248329a47810ad0cad9cb3