### PR TITLE
Add Clear button in main window

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -457,6 +457,10 @@ class MainWindow(QMainWindow):
         self.run_btn.clicked.connect(self.start_codex)
         button_bar.addWidget(self.run_btn)
 
+        self.clear_btn = QPushButton("Clear")
+        self.clear_btn.clicked.connect(self.prompt_edit.clear)
+        button_bar.addWidget(self.clear_btn)
+
         self.stop_btn = QPushButton("Stop")
         self.stop_btn.setEnabled(False)
         self.stop_btn.clicked.connect(self.stop_codex)


### PR DESCRIPTION
## Summary
- add a Clear button to reset the prompt editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb04b0ff88329ac770e1583cb7a80